### PR TITLE
refactor: centralize UI colors into constants.dart

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -24,6 +24,20 @@ const Color mdGrey400 = Color(0xFFBDBDBD);
 const Color dividerColor = Color(0xFFE0E0E0);
 const Color drawerHeaderTitle = Color(0xFFFFFFFF);
 
+// General UI Colors
+const Color colorWhite = Color(0xFFFFFFFF);         // Colors.white
+const Color colorBlack = Color(0xFF000000);          // Colors.black
+const Color colorBlackSecondary = Color(0x8A000000); // Colors.black54
+const Color colorGrey = Color(0xFF9E9E9E);           // Colors.grey
+const Color colorGreyInactive = Color(0xFF757575);   // inactive icon/text
+const Color colorGreyDial = Color(0xFF717171);       // speed dial text
+const Color colorTransparent = Color(0x00000000);    // Colors.transparent
+
+// Action/State Colors
+const Color colorRed = Color(0xFFF44336);            // Colors.red - delete/error/danger
+const Color colorBlue = Color(0xFF2196F3);           // Colors.blue - selected/active state
+const Color colorBlueLight = Color(0xFFE3F2FD);      // Colors.blue.shade50 - selected item bg
+
 //path to all the animation assets used
 const String animation = 'assets/animations/ic_anim_animation.gif';
 const String aniLeft = 'assets/animations/ic_anim_left.gif';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/providers/font_provider.dart';
 import 'package:badgemagic/providers/BadgeScanProvider.dart';
 import 'package:badgemagic/providers/getitlocator.dart';
@@ -76,7 +77,7 @@ class MyApp extends StatelessWidget {
               scaffoldMessengerKey: globals.scaffoldMessengerKey,
               debugShowCheckedModeBanner: false,
               theme: ThemeData(
-                colorSchemeSeed: Colors.white,
+                colorSchemeSeed: colorWhite,
                 useMaterial3: true,
               ),
               locale: locale ?? const Locale('en', 'US'),

--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -42,11 +42,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
             children: [
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorWhite,
                   borderRadius: BorderRadius.circular(10),
                   boxShadow: const [
                     BoxShadow(
-                      color: Colors.grey,
+                      color: colorGrey,
                       offset: Offset(0, 1),
                       blurRadius: 2.0,
                     ),
@@ -73,7 +73,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           wordSpacing: 3,
                           fontWeight: FontWeight.w400,
-                          color: Colors.black,
+                          color: colorBlack,
                           fontSize: 12,
                         ),
                         softWrap: true,
@@ -87,7 +87,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                               l10n.developedBy,
                               style: GoogleFonts.sora(
                                 fontWeight: FontWeight.w500,
-                                color: Colors.grey,
+                                color: colorGrey,
                               ),
                               overflow: TextOverflow.ellipsis,
                             ),
@@ -101,7 +101,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                                 l10n.fossasiaContributors,
                                 style: GoogleFonts.sora(
                                   fontWeight: FontWeight.w500,
-                                  color: Colors.red,
+                                  color: colorRed,
                                   decoration: TextDecoration.underline,
                                 ),
                                 overflow: TextOverflow.ellipsis,
@@ -117,11 +117,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
               SizedBox(height: 10),
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorWhite,
                   boxShadow: [
                     BoxShadow(
                       blurRadius: 1,
-                      color: Colors.grey,
+                      color: colorGrey,
                       offset: Offset(0, 1),
                     )
                   ],
@@ -137,7 +137,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorGrey,
                         ),
                       ),
                     ),
@@ -152,7 +152,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.black,
+                          color: colorBlack,
                         ),
                       ),
                       subtitle: Text(
@@ -160,7 +160,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorGrey,
                         ),
                         softWrap: true,
                       ),
@@ -173,11 +173,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
               SizedBox(height: 10),
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorWhite,
                   boxShadow: [
                     BoxShadow(
                       blurRadius: 1,
-                      color: Colors.grey,
+                      color: colorGrey,
                       offset: Offset(0, 1),
                     )
                   ],
@@ -193,7 +193,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 18,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorGrey,
                         ),
                       ),
                     ),
@@ -208,7 +208,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.black,
+                          color: colorBlack,
                         ),
                       ),
                       subtitle: Text(
@@ -216,7 +216,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorGrey,
                         ),
                         softWrap: true,
                       ),
@@ -230,14 +230,14 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                     //     style: GoogleFonts.sora(
                     //         fontSize: 16,
                     //         fontWeight: FontWeight.w500,
-                    //         color: Colors.black),
+                    //         color: colorBlack),
                     //   ),
                     //   subtitle: Text(
                     //     'Check third-party libs used on Badge Magic.',
                     //     style: GoogleFonts.sora(
                     //         fontSize: 12,
                     //         fontWeight: FontWeight.w500,
-                    //         color: Colors.grey),
+                    //         color: colorGrey),
                     //   ),
                     //   onTap: () => showLicenseDialog(context),
                     // ),

--- a/lib/view/badgeScanSettingsWidget.dart
+++ b/lib/view/badgeScanSettingsWidget.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/providers/BadgeScanProvider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -133,8 +134,8 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                             label: Text(
                                 'Remove (${provider.selectedIndices.length})'),
                             style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.red,
-                              foregroundColor: Colors.white,
+                              backgroundColor: colorRed,
+                              foregroundColor: colorWhite,
                             ),
                           ),
                       ],
@@ -153,13 +154,13 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                         decoration: BoxDecoration(
                           border: Border.all(
                             color:
-                                isSelected ? Colors.blue : Colors.grey.shade300,
+                                isSelected ? colorBlue : dividerColor,
                             width: isSelected ? 2 : 1,
                           ),
                           borderRadius: BorderRadius.circular(8),
                           color: isSelected
-                              ? Colors.blue.shade50
-                              : Colors.transparent,
+                              ? colorBlueLight
+                              : colorTransparent,
                         ),
                         child: Row(
                           children: [
@@ -167,7 +168,7 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                               value: isSelected,
                               onChanged: (value) =>
                                   provider.toggleSelection(index),
-                              activeColor: Colors.blue,
+                              activeColor: colorBlue,
                             ),
                             Expanded(
                               child: Padding(

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -201,11 +201,11 @@ class _DrawBadgeState extends State<DrawBadge> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, color: isSelected ? colorPrimary : Colors.black, size: 20),
+          Icon(icon, color: isSelected ? colorPrimary : colorBlack, size: 20),
           const SizedBox(height: 2),
           Text(label,
               style: TextStyle(
-                  color: isSelected ? colorPrimary : Colors.black,
+                  color: isSelected ? colorPrimary : colorBlack,
                   fontSize: 10)),
         ],
       ),
@@ -226,10 +226,10 @@ class _DrawBadgeState extends State<DrawBadge> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.refresh, color: Colors.black, size: 20),
+          const Icon(Icons.refresh, color: colorBlack, size: 20),
           const SizedBox(height: 2),
           Text(GetIt.instance.get<LocalizationService>().l10n.reset,
-              style: const TextStyle(color: Colors.black, fontSize: 10)),
+              style: const TextStyle(color: colorBlack, fontSize: 10)),
         ],
       ),
     );
@@ -270,10 +270,10 @@ class _DrawBadgeState extends State<DrawBadge> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.save, color: Colors.black, size: 20),
+          const Icon(Icons.save, color: colorBlack, size: 20),
           const SizedBox(height: 2),
           Text(GetIt.instance.get<LocalizationService>().l10n.save,
-              style: const TextStyle(color: Colors.black, fontSize: 10)),
+              style: const TextStyle(color: colorBlack, fontSize: 10)),
         ],
       ),
     );
@@ -299,11 +299,11 @@ class _DrawBadgeState extends State<DrawBadge> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(Icons.category,
-              color: _showShapeOptions ? colorPrimary : Colors.black, size: 20),
+              color: _showShapeOptions ? colorPrimary : colorBlack, size: 20),
           const SizedBox(height: 2),
           Text('Shapes', // Using hardcoded string for semantic label
               style: TextStyle(
-                  color: _showShapeOptions ? colorPrimary : Colors.black,
+                  color: _showShapeOptions ? colorPrimary : colorBlack,
                   fontSize: 10)),
         ],
       ),
@@ -315,7 +315,7 @@ class _DrawBadgeState extends State<DrawBadge> {
       animation: drawToggle,
       builder: (context, _) {
         final bool canUndo = drawToggle.canUndo;
-        final Color buttonColor = canUndo ? Colors.black : Colors.grey;
+        final Color buttonColor = canUndo ? colorBlack : colorGrey;
 
         return TextButton(
           onPressed: canUndo
@@ -345,7 +345,7 @@ class _DrawBadgeState extends State<DrawBadge> {
       animation: drawToggle,
       builder: (context, _) {
         final bool canRedo = drawToggle.canRedo;
-        final Color buttonColor = canRedo ? Colors.black : Colors.grey;
+        final Color buttonColor = canRedo ? colorBlack : colorGrey;
 
         return TextButton(
           onPressed: canRedo ? drawToggle.redo : null,
@@ -377,11 +377,11 @@ class _DrawBadgeState extends State<DrawBadge> {
         });
       },
       style: ElevatedButton.styleFrom(
-        foregroundColor: isSelected ? Colors.white : Colors.black,
-        backgroundColor: isSelected ? colorPrimary : Colors.white,
+        foregroundColor: isSelected ? colorWhite : colorBlack,
+        backgroundColor: isSelected ? colorPrimary : colorWhite,
         elevation: isSelected ? 2 : 1,
         side:
-            BorderSide(color: isSelected ? colorPrimary : Colors.grey.shade300),
+            BorderSide(color: isSelected ? colorPrimary : dividerColor),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
         minimumSize: const Size(55, 40),

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -313,7 +313,7 @@ class _HomeScreenState extends State<HomeScreen>
                                             value: fontProvider.selectedFont,
                                             icon: const SizedBox.shrink(),
                                             iconEnabledColor: mdGrey400,
-                                            dropdownColor: Colors.white,
+                                            dropdownColor: colorWhite,
                                             itemHeight: 48,
                                             isExpanded: true,
                                             style: TextStyle(
@@ -343,7 +343,7 @@ class _HomeScreenState extends State<HomeScreen>
                                                                 .selectedFont ==
                                                             null
                                                         ? dividerColor
-                                                        : Colors.transparent,
+                                                        : colorTransparent,
                                                     borderRadius:
                                                         BorderRadius.circular(
                                                             4),
@@ -356,7 +356,7 @@ class _HomeScreenState extends State<HomeScreen>
                                                                   .selectedFont ==
                                                               null
                                                           ? colorAccent
-                                                          : Colors.black,
+                                                          : colorBlack,
                                                       fontWeight: fontProvider
                                                                   .selectedFont ==
                                                               null
@@ -383,7 +383,7 @@ class _HomeScreenState extends State<HomeScreen>
                                                                   .selectedFont ==
                                                               font
                                                           ? dividerColor
-                                                          : Colors.transparent,
+                                                          : colorTransparent,
                                                       borderRadius:
                                                           BorderRadius.circular(
                                                               4),
@@ -396,7 +396,7 @@ class _HomeScreenState extends State<HomeScreen>
                                                                     .selectedFont ==
                                                                 font
                                                             ? colorAccent
-                                                            : Colors.black,
+                                                            : colorBlack,
                                                         fontWeight: fontProvider
                                                                     .selectedFont ==
                                                                 font
@@ -484,7 +484,7 @@ class _HomeScreenState extends State<HomeScreen>
                                 height: isPrefixIconClicked ? 170.h : 0,
                                 decoration: BoxDecoration(
                                   borderRadius: BorderRadius.circular(10.r),
-                                  color: Colors.grey[200],
+                                  color: progressSecondaryColor,
                                 ),
                                 margin: EdgeInsets.symmetric(
                                     horizontal: 15.w, vertical: 8.h),
@@ -516,7 +516,7 @@ class _HomeScreenState extends State<HomeScreen>
                                 fontSize: 14.sp,
                                 fontWeight: FontWeight.w500,
                               ),
-                              labelColor: Colors.black,
+                              labelColor: colorBlack,
                               unselectedLabelColor: mdGrey400,
                               indicatorColor: colorPrimary,
                               controller: _tabController,

--- a/lib/view/save_badge_screen.dart
+++ b/lib/view/save_badge_screen.dart
@@ -98,7 +98,7 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                 return SizedBox.shrink();
               }
               return IconButton(
-                icon: const Icon(Icons.delete, color: Colors.red),
+                icon: const Icon(Icons.delete, color: colorRed),
                 tooltip: l10n.deleteSelected,
                 onPressed: () async {
                   final confirm = await showDialog<bool>(
@@ -115,7 +115,7 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                           onPressed: () => Navigator.pop(context, true),
                           child: Text(
                             l10n.delete,
-                            style: const TextStyle(color: Colors.red),
+                            style: const TextStyle(color: colorRed),
                           ),
                         ),
                       ],
@@ -160,14 +160,14 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                     Text(
                       'No saved badges !',
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorBlack,
                         fontSize: 20.sp,
                       ),
                     ),
                     Text(
                       'Looks like there are no saved badges yet.',
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorBlack,
                         fontSize: 14.sp,
                       ),
                     ),
@@ -277,7 +277,7 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                               child: Text(
                                 l10n.transferButton,
                                 style: const TextStyle(
-                                  color: Colors.white,
+                                  color: colorWhite,
                                   fontSize: 16.0,
                                   fontWeight: FontWeight.w500,
                                 ),

--- a/lib/view/saved_clipart.dart
+++ b/lib/view/saved_clipart.dart
@@ -59,12 +59,12 @@ class _SavedClipartState extends State<SavedClipart> {
                   ),
                   Text(l10n.noSavedClipart,
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorBlack,
                         fontSize: 20.sp,
                       )),
                   Text(l10n.noSavedClipartMessage,
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorBlack,
                         fontSize: 14.sp,
                       )),
                 ],

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -167,8 +167,8 @@ class SettingsScreenState extends State<SettingsScreen> {
                               label: Text(
                                   'Remove (${provider.selectedIndices.length})'),
                               style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.red,
-                                foregroundColor: Colors.white,
+                                backgroundColor: colorRed,
+                                foregroundColor: colorWhite,
                               ),
                             ),
                         ],
@@ -185,13 +185,13 @@ class SettingsScreenState extends State<SettingsScreen> {
                       decoration: BoxDecoration(
                         border: Border.all(
                           color:
-                              isSelected ? Colors.blue : Colors.grey.shade300,
+                              isSelected ? colorBlue : dividerColor,
                           width: isSelected ? 2 : 1,
                         ),
                         borderRadius: BorderRadius.circular(8),
                         color: isSelected
-                            ? Colors.blue.shade50
-                            : Colors.transparent,
+                            ? colorBlueLight
+                            : colorTransparent,
                       ),
                       child: Row(
                         children: [
@@ -199,7 +199,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                             value: isSelected,
                             onChanged: (value) =>
                                 provider.toggleSelection(index),
-                            activeColor: Colors.blue,
+                            activeColor: colorBlue,
                           ),
                           Expanded(
                             child: Padding(
@@ -255,7 +255,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                       child: Text(
                         l10n.saveSettings,
                         style: const TextStyle(
-                          color: Colors.black,
+                          color: colorBlack,
                         ),
                       ),
                     ),

--- a/lib/view/widgets/about_us_daialog.dart
+++ b/lib/view/widgets/about_us_daialog.dart
@@ -30,7 +30,7 @@ class LicenseDialogContainer extends StatelessWidget {
               style: GoogleFonts.sora(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Colors.black,
+                color: colorBlack,
               ),
             ),
             // SizedBox(
@@ -48,7 +48,7 @@ class LicenseDialogContainer extends StatelessWidget {
                 decoration: TextDecoration.underline,
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Colors.blue,
+                color: colorBlue,
               ),
             ),
           ),
@@ -57,7 +57,7 @@ class LicenseDialogContainer extends StatelessWidget {
         Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(4),
-            color: Colors.grey[300],
+            color: dividerColor,
           ),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 10),
@@ -68,7 +68,7 @@ class LicenseDialogContainer extends StatelessWidget {
                 letterSpacing: 0.6,
                 fontSize: 10,
                 fontWeight: FontWeight.w500,
-                color: Colors.black,
+                color: colorBlack,
               ),
             ),
           ),
@@ -84,7 +84,7 @@ void showLicenseDialog(BuildContext context) {
     builder: (BuildContext context) {
       return Dialog(
         insetPadding: EdgeInsets.all(8),
-        backgroundColor: Colors.white,
+        backgroundColor: colorWhite,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8.0),
         ),
@@ -95,7 +95,7 @@ void showLicenseDialog(BuildContext context) {
               Container(
                 padding: const EdgeInsets.only(left: 16.0, top: 16, bottom: 8),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorWhite,
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(10.0),
                     topRight: Radius.circular(10.0),
@@ -108,7 +108,7 @@ void showLicenseDialog(BuildContext context) {
                     style: GoogleFonts.inter(
                       fontWeight: FontWeight.w400,
                       fontSize: 20,
-                      color: Colors.black,
+                      color: colorBlack,
                     ),
                   ),
                 ),
@@ -222,7 +222,7 @@ void showLicenseDialog(BuildContext context) {
                   onPressed: () => Navigator.of(context).pop(),
                   child: const Text(
                     'CLOSE',
-                    style: TextStyle(color: Colors.red),
+                    style: TextStyle(color: colorRed),
                   ),
                 ),
               ),

--- a/lib/view/widgets/animation_container.dart
+++ b/lib/view/widgets/animation_container.dart
@@ -91,7 +91,7 @@ class _AniContainerState extends State<AniContainer> {
           animationCardState.setAnimationMode(badgeAnimation);
         },
         child: Card(
-          surfaceTintColor: Colors.white,
+          surfaceTintColor: colorWhite,
           color: animationCardState.isAnimationActive(badgeAnimation)
               ? colorPrimaryDark
               : drawerHeaderTitle,
@@ -106,8 +106,8 @@ class _AniContainerState extends State<AniContainer> {
                         size: 36,
                         color:
                             animationCardState.isAnimationActive(badgeAnimation)
-                                ? Colors.white
-                                : const Color.fromARGB(255, 117, 117, 117),
+                                ? colorWhite
+                                : colorGreyInactive,
                       )
                     : (widget.animation != null
                         ? Image.asset(
@@ -115,7 +115,7 @@ class _AniContainerState extends State<AniContainer> {
                             fit: BoxFit.fill,
                             color: animationCardState
                                     .isAnimationActive(badgeAnimation)
-                                ? Colors.white
+                                ? colorWhite
                                 : null,
                             colorBlendMode: animationCardState
                                     .isAnimationActive(badgeAnimation)
@@ -131,8 +131,8 @@ class _AniContainerState extends State<AniContainer> {
                   style: TextStyle(
                     fontSize: 9.sp,
                     color: animationCardState.isAnimationActive(badgeAnimation)
-                        ? Colors.white
-                        : Colors.black,
+                        ? colorWhite
+                        : colorBlack,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,

--- a/lib/view/widgets/badge_delete_dialog.dart
+++ b/lib/view/widgets/badge_delete_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:badgemagic/services/localization_service.dart';
@@ -24,7 +25,7 @@ class DeleteBadgeDialog extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  Icon(Icons.delete, color: Colors.black),
+                  Icon(Icons.delete, color: colorBlack),
                   SizedBox(width: 10.w),
                   Text(l10n.delete,
                       style: TextStyle(
@@ -45,13 +46,13 @@ class DeleteBadgeDialog extends StatelessWidget {
                         Navigator.of(context).pop(false);
                       },
                       child: Text(l10n.cancel,
-                          style: const TextStyle(color: Colors.red))),
+                          style: const TextStyle(color: colorRed))),
                   TextButton(
                       onPressed: () {
                         Navigator.of(context).pop(true);
                       },
                       child: Text(l10n.ok,
-                          style: const TextStyle(color: Colors.red))),
+                          style: const TextStyle(color: colorRed))),
                 ],
               ),
             ],

--- a/lib/view/widgets/clipart_list_view.dart
+++ b/lib/view/widgets/clipart_list_view.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:badgemagic/bademagic_module/utils/file_helper.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/bademagic_module/utils/image_utils.dart';
 import 'package:badgemagic/view/draw_badge_screen.dart';
 import 'package:badgemagic/view/widgets/badge_delete_dialog.dart';
@@ -34,7 +35,7 @@ class SavedClipartListView extends StatelessWidget {
           height: 100.h,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(5.r),
-            color: Colors.white,
+            color: colorWhite,
           ),
           child: Row(
             children: [
@@ -59,7 +60,7 @@ class SavedClipartListView extends StatelessWidget {
               Container(
                 width: 1.w,
                 height: 80.h,
-                color: Colors.black,
+                color: colorBlack,
               ),
               SizedBox(
                 width: 130.w,

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -24,7 +24,7 @@ class CommonScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      backgroundColor: Colors.white,
+      backgroundColor: colorWhite,
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         leading: Builder(builder: (context) {
@@ -34,14 +34,14 @@ class CommonScaffold extends StatelessWidget {
             },
             icon: const Icon(
               Icons.menu,
-              color: Colors.white,
+              color: colorWhite,
             ),
           );
         }),
         backgroundColor: colorPrimary,
         title: Text(
           title,
-          style: const TextStyle(color: Colors.white),
+          style: const TextStyle(color: colorWhite),
         ),
         actions: [
           if (actions != null) ...actions!,

--- a/lib/view/widgets/effects_container.dart
+++ b/lib/view/widgets/effects_container.dart
@@ -70,7 +70,7 @@ class _EffectContainerState extends State<EffectContainer> {
           );
         },
         child: Card(
-          surfaceTintColor: Colors.white,
+          surfaceTintColor: colorWhite,
           color: effectCardState.isEffectActive(badgeEffect)
               ? colorAccent
               : drawerHeaderTitle,
@@ -83,7 +83,7 @@ class _EffectContainerState extends State<EffectContainer> {
                   widget.effect,
                   fit: BoxFit.contain,
                   color: effectCardState.isEffectActive(badgeEffect)
-                      ? Colors.white
+                      ? colorWhite
                       : null,
                   colorBlendMode: effectCardState.isEffectActive(badgeEffect)
                       ? BlendMode.srcIn
@@ -97,8 +97,8 @@ class _EffectContainerState extends State<EffectContainer> {
                   style: TextStyle(
                     fontSize: 10.sp,
                     color: effectCardState.isEffectActive(badgeEffect)
-                        ? Colors.white
-                        : Colors.black,
+                        ? colorWhite
+                        : colorBlack,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -41,7 +41,7 @@ class _BMDrawerState extends State<BMDrawer> {
             aspectRatio: 16 / 9,
             child: DrawerHeader(
               decoration: BoxDecoration(
-                color: Colors.red,
+                color: colorRed,
               ),
               child: Center(
                 child: Text(
@@ -102,7 +102,7 @@ class _BMDrawerState extends State<BMDrawer> {
             child: Text(
               l10n.other,
               style: const TextStyle(
-                color: Colors.black54,
+                color: colorBlackSecondary,
                 fontWeight: FontWeight.bold,
                 fontSize: 14,
               ),
@@ -164,18 +164,18 @@ class _BMDrawerState extends State<BMDrawer> {
       leading: icon != null
           ? Icon(
               icon,
-              color: currentIndex == index ? colorAccent : Colors.black,
+              color: currentIndex == index ? colorAccent : colorBlack,
             )
           : Image.asset(
               assetIcon!,
               height: 18,
-              color: currentIndex == index ? colorAccent : Colors.black,
+              color: currentIndex == index ? colorAccent : colorBlack,
             ),
       title: title is String
           ? Text(
               title,
               style: TextStyle(
-                color: currentIndex == index ? colorAccent : Colors.black,
+                color: currentIndex == index ? colorAccent : colorBlack,
                 fontWeight: FontWeight.bold,
                 fontSize: 14,
               ),

--- a/lib/view/widgets/save_badge_card.dart
+++ b/lib/view/widgets/save_badge_card.dart
@@ -43,7 +43,7 @@ class SaveBadgeCard extends StatelessWidget {
       padding: EdgeInsets.all(6.dg),
       margin: EdgeInsets.all(10.dg),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: colorWhite,
         borderRadius: BorderRadius.circular(6.dg),
         boxShadow: [
           BoxShadow(
@@ -88,7 +88,7 @@ class SaveBadgeCard extends StatelessWidget {
                       icon: Image.asset(
                         "assets/icons/t_play.png",
                         height: 20,
-                        color: Colors.black,
+                        color: colorBlack,
                       ),
                       onPressed: () {
                         provider.savedBadgeAnimation(
@@ -100,7 +100,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.edit,
-                        color: Colors.black,
+                        color: colorBlack,
                       ),
                       onPressed: () async {
                         // Show confirmation dialog before editing
@@ -122,7 +122,7 @@ class SaveBadgeCard extends StatelessWidget {
                       icon: Image.asset(
                         "assets/icons/t_updown.png",
                         height: 24.h,
-                        color: Colors.black,
+                        color: colorBlack,
                       ),
                       onPressed: () {
                         logger.d("BadgeData: ${badgeData.value}");
@@ -135,7 +135,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.share,
-                        color: Colors.black,
+                        color: colorBlack,
                       ),
                       onPressed: () {
                         file.shareBadgeData(badgeData.key);
@@ -144,7 +144,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.delete,
-                        color: Colors.black,
+                        color: colorBlack,
                       ),
                       onPressed: () async {
                         //add a dialog for confirmation before deleting
@@ -180,7 +180,7 @@ class SaveBadgeCard extends StatelessWidget {
                         children: [
                           Image.asset(
                             "assets/icons/flash.png",
-                            color: Colors.white,
+                            color: colorWhite,
                             height: 14.h,
                           )
                         ],
@@ -204,7 +204,7 @@ class SaveBadgeCard extends StatelessWidget {
                         children: [
                           Image.asset(
                             "assets/icons/square.png",
-                            color: Colors.white,
+                            color: colorWhite,
                             height: 14.h,
                           )
                         ],
@@ -227,7 +227,7 @@ class SaveBadgeCard extends StatelessWidget {
                         children: [
                           Image.asset(
                             "assets/icons/t_invert.png",
-                            color: Colors.white,
+                            color: colorWhite,
                             height: 14.h,
                           )
                         ],
@@ -250,7 +250,7 @@ class SaveBadgeCard extends StatelessWidget {
                     children: [
                       Image.asset(
                         "assets/icons/t_double.png",
-                        color: Colors.white,
+                        color: colorWhite,
                         height: 14.h,
                       ),
                       const SizedBox(width: 4),
@@ -258,7 +258,7 @@ class SaveBadgeCard extends StatelessWidget {
                         Speed.getIntValue(
                           file.jsonToData(badgeData.value).messages[0].speed,
                         ).toString(),
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: colorWhite),
                       )
                     ],
                   ),
@@ -283,7 +283,7 @@ class SaveBadgeCard extends StatelessWidget {
                         .split('.')
                         .last
                         .toUpperCase(),
-                    style: const TextStyle(color: Colors.white),
+                    style: const TextStyle(color: colorWhite),
                   ),
                 ),
               ),

--- a/lib/view/widgets/save_badge_dialog.dart
+++ b/lib/view/widgets/save_badge_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:badgemagic/bademagic_module/utils/toast_utils.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/badge_effect/flash_effect.dart';
 import 'package:badgemagic/badge_effect/marquee_effect.dart';
 import 'package:badgemagic/providers/animation_badge_provider.dart';
@@ -65,7 +66,7 @@ class SaveBadgeDialog extends StatelessWidget {
               l10n.badgeName,
               style: const TextStyle(
                 fontWeight: FontWeight.w400,
-                color: Colors.red,
+                color: colorRed,
               ),
             ),
             const SizedBox(height: 10),
@@ -74,10 +75,10 @@ class SaveBadgeDialog extends StatelessWidget {
               autofocus: true,
               decoration: const InputDecoration(
                 enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.red),
+                  borderSide: BorderSide(color: colorRed),
                 ),
                 focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.red, width: 2),
+                  borderSide: BorderSide(color: colorRed, width: 2),
                 ),
               ),
             ),
@@ -90,7 +91,7 @@ class SaveBadgeDialog extends StatelessWidget {
                     },
                     child: Text(
                       l10n.cancel,
-                      style: const TextStyle(color: Colors.red),
+                      style: const TextStyle(color: colorRed),
                     )),
                 TextButton(
                   onPressed: () async {
@@ -233,7 +234,7 @@ class SaveBadgeDialog extends StatelessWidget {
                   },
                   child: Text(
                     'Save',
-                    style: const TextStyle(color: Colors.red),
+                    style: const TextStyle(color: colorRed),
                   ),
                 ),
               ],

--- a/lib/view/widgets/special_animation_dialog.dart
+++ b/lib/view/widgets/special_animation_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/services/localization_service.dart';
 import 'package:get_it/get_it.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +24,7 @@ Future<bool?> showSpecialAnimationDialog(
                   Expanded(
                     child: Text(
                       textToClear,
-                      style: const TextStyle(fontSize: 13, color: Colors.grey),
+                      style: const TextStyle(fontSize: 13, color: colorGrey),
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),

--- a/lib/view/widgets/speedial.dart
+++ b/lib/view/widgets/speedial.dart
@@ -215,7 +215,7 @@ class _RadialDialState extends State<RadialDial> {
         CustomPaint(
           painter: InnerDialPainter(),
           child: Container(
-            color: Colors.transparent,
+            color: colorTransparent,
             width: 180.w,
           ),
         ),
@@ -246,7 +246,7 @@ class _RadialDialState extends State<RadialDial> {
             style: TextStyle(
               fontSize: 50.sp,
               fontWeight: FontWeight.w600,
-              color: const Color.fromRGBO(113, 113, 113, 1),
+              color: colorGreyDial,
             ),
           ),
         ),

--- a/lib/view/widgets/vectorview.dart
+++ b/lib/view/widgets/vectorview.dart
@@ -55,8 +55,8 @@ class _VectorGridViewState extends State<VectorGridView> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(5),
               ),
-              surfaceTintColor: Colors.white,
-              color: Colors.white,
+              surfaceTintColor: colorWhite,
+              color: colorWhite,
               elevation: 2,
               child: Center(
                 child: Icon(
@@ -76,8 +76,8 @@ class _VectorGridViewState extends State<VectorGridView> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(5),
               ),
-              surfaceTintColor: Colors.white,
-              color: Colors.white,
+              surfaceTintColor: colorWhite,
+              color: colorWhite,
               elevation: 2,
               child: Padding(
                   padding: const EdgeInsets.all(2.0),


### PR DESCRIPTION
Fixes #1665

## Changes 
- Replaced hardcoded Colors.* across UI layer

- Added reusable color constants

- No visual or behavioral changes

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ x ] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ x ] **No end of file edits**: No modifications done at end of resource files.
- [ x ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ x ] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Centralize UI color usage by replacing hardcoded Flutter Colors with shared color constants across the app.

Enhancements:
- Introduce reusable color constants in constants.dart for common UI colors and semantic states.
- Refactor multiple screens and widgets to use the new color constants for backgrounds, text, icons, dialogs, and cards, ensuring consistent theming.
- Adjust theme and selection states to rely on the centralized color constants while preserving existing visual behavior.