### PR TITLE
feat: Categorize cliparts and add tab bar

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -248,5 +248,13 @@
   "couldNotGenerateQrImage": "Could not generate QR image.",
   "couldNotShareQrImage": "Could not share QR image.",
   "qrShareInstruction": "Scan this code from another device, or tap share to send the QR image.",
-  "turnBLEOn": "Please turn on Bluetooth in your settings"
+  "turnBLEOn": "Please turn on Bluetooth in your settings",
+  "clipartCategoryPersonalized": "Personalized",
+  "clipartCategoryFaces": "Faces & Hands",
+  "clipartCategoryHeartsStars": "Hearts & Stars",
+  "clipartCategoryArrows": "Arrows",
+  "clipartCategoryMediaTime": "Media & Time",
+  "clipartCategoryNatureWeather": "Nature & Weather",
+  "clipartCategorySymbolsShapes": "Symbols & Shapes",
+  "clipartCategoryObjectsRetro": "Objects & Retro"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -173,5 +173,13 @@
     "saveSettings": "सेटिंग्स सेव करें",
     "connectToAnyBadge": "किसी भी बैज से कनेक्ट करें",
     "badgeNameHint": "बैज का नाम",
-    "pleaseSelectClipart": "सेव करने से पहले कृपया तस्वीर बनाएं या चुनें"
+    "pleaseSelectClipart": "सेव करने से पहले कृपया तस्वीर बनाएं या चुनें",
+    "clipartCategoryPersonalized": "निजी",
+    "clipartCategoryFaces": "चेहरे और हाथ",
+    "clipartCategoryHeartsStars": "दिल और सितारे",
+    "clipartCategoryArrows": "तीर",
+    "clipartCategoryMediaTime": "मीडिया और समय",
+    "clipartCategoryNatureWeather": "प्रकृति और मौसम",
+    "clipartCategorySymbolsShapes": "प्रतीक और आकार",
+    "clipartCategoryObjectsRetro": "वस्तुएं और रेट्रो"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -216,5 +216,13 @@
   "triangle": "Triangolo",
   "clipartSavedSuccessfully": "Clipart salvato con successo",
   "badgeScanMode": "Modalità Scansione Badge",
-  "pleaseSelectClipart": "Si prega di disegnare o selezionare un clipart prima di salvare"
+  "pleaseSelectClipart": "Si prega di disegnare o selezionare un clipart prima di salvare",
+  "clipartCategoryPersonalized": "Personalizzati",
+  "clipartCategoryFaces": "Volti e Mani",
+  "clipartCategoryHeartsStars": "Cuori e Stelle",
+  "clipartCategoryArrows": "Frecce",
+  "clipartCategoryMediaTime": "Media e Tempo",
+  "clipartCategoryNatureWeather": "Natura e Meteo",
+  "clipartCategorySymbolsShapes": "Simboli e Forme",
+  "clipartCategoryObjectsRetro": "Oggetti e Retro"
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -487,24 +487,17 @@ class _HomeScreenState extends State<HomeScreen>
                     child: Visibility(
                       visible: isPrefixIconClicked,
                       child: Container(
-                        height: isPrefixIconClicked ? 200.h : 0,
+                        height: isPrefixIconClicked ? 170.h : 0,
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(10.r),
                           color: colorSurfaceMuted,
                         ),
                         margin: EdgeInsets.symmetric(
                             horizontal: 15.w, vertical: 8.h),
-                        padding:
-                            EdgeInsets.symmetric(vertical: 10.h, horizontal: 8),
-                        child: Scrollbar(
-                          controller: _vectorScrollController,
-                          thumbVisibility: true,
-                          trackVisibility: true,
-                          thickness: 4.0,
-                          radius: const Radius.circular(10),
-                          child: VectorGridView(
-                              controller: _vectorScrollController),
-                        ),
+                        padding: EdgeInsets.symmetric(
+                            vertical: 10.h, horizontal: 10.w),
+                        child:
+                            VectorGridView(controller: _vectorScrollController),
                       ),
                     ),
                   );

--- a/lib/view/widgets/vectorview.dart
+++ b/lib/view/widgets/vectorview.dart
@@ -1,7 +1,10 @@
 import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/providers/imageprovider.dart';
+import 'package:badgemagic/services/localization_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:get_it/get_it.dart';
 import 'package:provider/provider.dart';
 
 const List<List<String>> _clipartGroups = [
@@ -58,6 +61,77 @@ List<int> _groupRank(String assetPath) {
   return [_clipartGroups.length, 0];
 }
 
+int _getCategoryIndex(String assetPath) {
+  final name = assetPath.toLowerCase();
+
+  // 1. Faces & Hands
+  if (name.contains('smile_face') ||
+      name.contains('face') ||
+      name.contains('sad_face') ||
+      name.contains('expressionless') ||
+      name.contains('without_mouth') ||
+      name.contains('mustache') ||
+      name.contains('thumbs') ||
+      name.contains('thumb')) {
+    return 1;
+  }
+
+  // 2. Hearts & Stars
+  if (name.contains('heart') || name.contains('star')) {
+    return 2;
+  }
+
+  // 3. Arrows
+  if (name.contains('arrow') || name.contains('subdirectory')) {
+    return 3;
+  }
+
+  // 4. Media & Time
+  if (name.contains('play') ||
+      name.contains('pause') ||
+      name.contains('music') ||
+      name.contains('clock')) {
+    return 4;
+  }
+
+  // 5. Nature & Weather
+  if (name.contains('sun') ||
+      name.contains('moon') ||
+      name.contains('lightning') ||
+      name.contains('bolt')) {
+    return 5;
+  }
+
+  // 6. Symbols & Shapes
+  if (name.contains('check') ||
+      name.contains('tick') ||
+      name.contains('cross') ||
+      name.contains('block') ||
+      name.contains('info') ||
+      name.contains('diamond') ||
+      name.contains('hexagon') ||
+      name.contains('square') ||
+      name.contains('triangle') ||
+      name.contains('bar')) {
+    return 6;
+  }
+
+  // 7. Objects & Retro
+  return 7;
+}
+
+class ClipartCategory {
+  final String title;
+  final IconData icon;
+  final List<dynamic> keys;
+
+  ClipartCategory({
+    required this.title,
+    required this.icon,
+    required this.keys,
+  });
+}
+
 class VectorGridView extends StatefulWidget {
   final ScrollController? controller;
 
@@ -74,10 +148,15 @@ class _VectorGridViewState extends State<VectorGridView> {
 
   static final RegExp _placeholderRegExp = RegExp(r'<<(\d+)>>');
 
+  final List<GlobalKey> _sectionKeys = List.generate(8, (_) => GlobalKey());
+  int _activeCategoryIndex = 0;
+  bool _isAutoScrolling = false;
+
   @override
   void initState() {
     super.initState();
     _scrollController = widget.controller ?? ScrollController();
+    _scrollController.addListener(_onScroll);
     _messageController =
         Provider.of<InlineImageProvider>(context, listen: false)
             .getController();
@@ -103,19 +182,59 @@ class _VectorGridViewState extends State<VectorGridView> {
     return -1;
   }
 
-  int _columnsForWidth(double width) {
-    if (width < 300) return (width / 48).round().clamp(3, 6);
-    if (width <= 520) return 7;
-    return (width / 54).round();
-  }
-
   @override
   void dispose() {
     _messageController.removeListener(_updateSelectionFromText);
+    _scrollController.removeListener(_onScroll);
     if (widget.controller == null) {
       _scrollController.dispose();
     }
     super.dispose();
+  }
+
+  void _onScroll() {
+    if (_isAutoScrolling || !mounted) return;
+
+    final viewPortBox = context.findRenderObject() as RenderBox?;
+    if (viewPortBox == null) return;
+
+    int activeIndex = 0;
+    for (int i = 0; i < _sectionKeys.length; i++) {
+      final sectionContext = _sectionKeys[i].currentContext;
+      if (sectionContext != null) {
+        final box = sectionContext.findRenderObject() as RenderBox?;
+        if (box != null) {
+          final localPos =
+              box.localToGlobal(Offset.zero, ancestor: viewPortBox);
+          if (localPos.dy <= 40.0) {
+            activeIndex = i;
+          }
+        }
+      }
+    }
+
+    if (activeIndex != _activeCategoryIndex) {
+      setState(() {
+        _activeCategoryIndex = activeIndex;
+      });
+    }
+  }
+
+  void _scrollToSection(int index) async {
+    final sectionContext = _sectionKeys[index].currentContext;
+    if (sectionContext != null) {
+      setState(() {
+        _activeCategoryIndex = index;
+        _isAutoScrolling = true;
+      });
+      await Scrollable.ensureVisible(
+        sectionContext,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+      _isAutoScrolling = false;
+    }
   }
 
   @override
@@ -146,87 +265,225 @@ class _VectorGridViewState extends State<VectorGridView> {
         return pathFor(a).compareTo(pathFor(b));
       });
 
-    final keys = <dynamic>[
-      ...savedKeys,
-      ...defaultKeys,
+    final List<List<dynamic>> defaultGroupedKeys = List.generate(8, (_) => []);
+    for (final key in defaultKeys) {
+      final index = _getCategoryIndex(pathFor(key));
+      defaultGroupedKeys[index].add(key);
+    }
+
+    final l10n = GetIt.instance.get<LocalizationService>().l10n;
+
+    final categories = [
+      ClipartCategory(
+        title: l10n.clipartCategoryPersonalized,
+        icon: Icons.brush_outlined,
+        keys: savedKeys,
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryFaces,
+        icon: Icons.sentiment_satisfied_alt_outlined,
+        keys: defaultGroupedKeys[1],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryHeartsStars,
+        icon: Icons.favorite_border_rounded,
+        keys: defaultGroupedKeys[2],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryArrows,
+        icon: Icons.arrow_outward_rounded,
+        keys: defaultGroupedKeys[3],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryMediaTime,
+        icon: Icons.play_circle_outline_rounded,
+        keys: defaultGroupedKeys[4],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryNatureWeather,
+        icon: Icons.wb_sunny_outlined,
+        keys: defaultGroupedKeys[5],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategorySymbolsShapes,
+        icon: Icons.category_outlined,
+        keys: defaultGroupedKeys[6],
+      ),
+      ClipartCategory(
+        title: l10n.clipartCategoryObjectsRetro,
+        icon: Icons.videogame_asset_outlined,
+        keys: defaultGroupedKeys[7],
+      ),
     ];
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final int crossAxisCount = _columnsForWidth(constraints.maxWidth);
-        return GridView.builder(
-          controller: _scrollController,
-          shrinkWrap: true,
-          physics: const AlwaysScrollableScrollPhysics(),
-          padding: const EdgeInsets.only(right: 4.0),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            childAspectRatio: 1.0,
-            crossAxisSpacing: 2.0,
-            mainAxisSpacing: 2.0,
+    return Column(
+      children: [
+        // Category Tab Bar
+        Container(
+          height: 38.h,
+          padding: EdgeInsets.symmetric(horizontal: 4.w),
+          decoration: const BoxDecoration(
+            color: Colors.transparent,
           ),
-          itemCount: keys.length + 1,
-          itemBuilder: (context, index) {
-            if (index == 0) {
-              return GestureDetector(
-                onTap: () {
-                  Navigator.pushNamed(context, '/drawBadge');
-                },
-                child: Card(
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(5),
-                  ),
-                  surfaceTintColor: colorSurface,
-                  color: colorSurface,
-                  elevation: 2,
-                  child: Center(
+          child: NotificationListener<ScrollNotification>(
+            onNotification: (notification) => true,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: categories.length,
+              itemBuilder: (context, index) {
+                final cat = categories[index];
+                final isActive = index == _activeCategoryIndex;
+                return GestureDetector(
+                  onTap: () => _scrollToSection(index),
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 10.w),
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: isActive ? colorPrimary : Colors.transparent,
+                          width: 2.h,
+                        ),
+                      ),
+                    ),
                     child: Icon(
-                      Icons.add_circle_outline_rounded,
-                      color: colorPrimary,
+                      cat.icon,
+                      color: isActive ? colorPrimary : Colors.grey[600],
+                      size: 20.dg,
                     ),
                   ),
-                ),
-              );
-            }
-
-            final imageKey = keys[index - 1];
-
-            final imageBytes = inlineImageProvider.imageCache[imageKey];
-
-            if (imageBytes == null) {
-              return const SizedBox.shrink();
-            }
-
-            final bool isSelected =
-                _selectedIndices.contains(_indexForKey(imageKey));
-
-            return GestureDetector(
-              onTap: () {
-                inlineImageProvider.insertInlineImage(imageKey);
+                );
               },
-              child: Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(5),
-                  side: isSelected
-                      ? BorderSide(color: colorTextSecondary, width: 2)
-                      : BorderSide.none,
-                ),
-                surfaceTintColor: colorSurface,
-                color: isSelected ? colorBorder : colorSurface,
-                elevation: isSelected ? 4 : 2,
-                child: Padding(
-                  padding: const EdgeInsets.all(2.0),
-                  child: Image.memory(
-                    imageBytes,
-                    fit: BoxFit.contain,
-                    filterQuality: FilterQuality.none,
-                  ),
+            ),
+          ),
+        ),
+
+        // Scrollable Grids
+        Expanded(
+          child: Scrollbar(
+            controller: _scrollController,
+            thumbVisibility: true,
+            trackVisibility: true,
+            thickness: 4.0,
+            radius: const Radius.circular(10),
+            child: ScrollConfiguration(
+              behavior:
+                  ScrollConfiguration.of(context).copyWith(scrollbars: false),
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                padding: EdgeInsets.only(right: 12.w, bottom: 8.h),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: List.generate(categories.length, (catIndex) {
+                    final cat = categories[catIndex];
+
+                    if (catIndex != 0 && cat.keys.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+
+                    return Column(
+                      key: _sectionKeys[catIndex],
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: EdgeInsets.only(
+                              left: 4.w, top: 12.h, bottom: 6.h),
+                          child: Text(
+                            cat.title,
+                            style: TextStyle(
+                              fontSize: 12.sp,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                        ),
+                        GridView.builder(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 9,
+                            childAspectRatio: 1.0,
+                            crossAxisSpacing: 4.0,
+                            mainAxisSpacing: 4.0,
+                          ),
+                          itemCount: cat.keys.length + (catIndex == 0 ? 1 : 0),
+                          itemBuilder: (context, index) {
+                            if (catIndex == 0 && index == 0) {
+                              return GestureDetector(
+                                onTap: () {
+                                  Navigator.pushNamed(context, '/drawBadge');
+                                },
+                                child: Card(
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(5),
+                                  ),
+                                  surfaceTintColor: colorSurface,
+                                  color: colorSurface,
+                                  elevation: 2,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(6.0),
+                                    child: FittedBox(
+                                      fit: BoxFit.contain,
+                                      child: Icon(
+                                        Icons.add_circle_outline_rounded,
+                                        color: colorPrimary,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            }
+
+                            final imageKey = catIndex == 0
+                                ? cat.keys[index - 1]
+                                : cat.keys[index];
+                            final imageBytes =
+                                inlineImageProvider.imageCache[imageKey];
+
+                            if (imageBytes == null) {
+                              return const SizedBox.shrink();
+                            }
+
+                            final bool isSelected = _selectedIndices
+                                .contains(_indexForKey(imageKey));
+
+                            return GestureDetector(
+                              onTap: () {
+                                inlineImageProvider.insertInlineImage(imageKey);
+                              },
+                              child: Card(
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(5),
+                                  side: isSelected
+                                      ? BorderSide(
+                                          color: colorTextSecondary, width: 2)
+                                      : BorderSide.none,
+                                ),
+                                surfaceTintColor: colorSurface,
+                                color: isSelected ? colorBorder : colorSurface,
+                                elevation: isSelected ? 4 : 2,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(6.0),
+                                  child: Image.memory(
+                                    imageBytes,
+                                    fit: BoxFit.contain,
+                                    filterQuality: FilterQuality.none,
+                                  ),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    );
+                  }),
                 ),
               ),
-            );
-          },
-        );
-      },
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Fixes #1765

## Changes 
- Divided the clipart selector on the Home Screen into 8 distinct categories (Personalized at the top, followed by default categories: Faces & Hands, Hearts & Stars, Arrows, Media & Time, Nature & Weather, Symbols & Shapes, Objects & Retro).
- Added a horizontal category tab selector bar at the top of the clipart grid with appropriate icons for each category.
- Implemented vertical headers for each category section.
- Added bidirectional scroll synchronization (tapping a category tab scrolls to that section; scrolling the list updates the active tab highlight).
- Wrapped the category tab bar in a horizontal scroll notification listener to avoid conflicts with the parent vertical scrollbar.
- Added localized translations for each category title in:
  - [app_en.arb](file:///d:/badgemagic-app/lib/l10n/app_en.arb)
  - [app_hi.arb](file:///d:/badgemagic-app/lib/l10n/app_hi.arb)
  - [app_it.arb](file:///d:/badgemagic-app/lib/l10n/app_it.arb)

## Screenshots / Recordings  


https://github.com/user-attachments/assets/3a90e7a4-6fe0-486a-9d64-9b41251be317



**Checklist**:
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.