### PR TITLE
fix: Discover OEM badges missing 0xFEE0 in adverts

### DIFF
--- a/lib/bademagic_module/bluetooth/scan_state.dart
+++ b/lib/bademagic_module/bluetooth/scan_state.dart
@@ -41,13 +41,19 @@ class ScanState extends NormalBleState {
                 .where((e) => e.isNotEmpty)
                 .toList();
 
+            // device.services here is what was in the advertisement, not the
+            // full GATT table. OEM badges advertise no service UUIDs at all,
+            // so this alone rejects them - match the advertised name too.
             final matchesUuid = device.services.contains(targetServiceUuid);
+            final rawName = (device.name ?? "").trim();
+            final matchesBadgeName =
+                badgeNamePrefixes.any((prefix) => rawName.startsWith(prefix));
 
-            final deviceName = (device.name ?? "").trim().toLowerCase();
+            final deviceName = rawName.toLowerCase();
             final matchesName = mode == BadgeScanMode.any ||
                 normalizedAllowedNames.contains(deviceName);
 
-            if (matchesUuid && matchesName) {
+            if ((matchesUuid || matchesBadgeName) && matchesName) {
               isCompleted = true;
               timeoutTimer?.cancel();
               await UniversalBle.stopScan();
@@ -76,9 +82,15 @@ class ScanState extends NormalBleState {
         },
       );
 
+      // Supplying withNamePrefix switches universal_ble into custom-filter
+      // mode, where the *native* scanner runs unfiltered and matching happens
+      // in the plugin with OR semantics across filter kinds. That is what lets
+      // OEM badges - which advertise no service UUIDs - be seen at all, and it
+      // mirrors what the stock vendor app does.
       await UniversalBle.startScan(
         scanFilter: ScanFilter(
           withServices: [targetServiceUuid],
+          withNamePrefix: badgeNamePrefixes,
         ),
       );
 

--- a/lib/bademagic_module/bluetooth/scan_state.dart
+++ b/lib/bademagic_module/bluetooth/scan_state.dart
@@ -19,6 +19,32 @@ class ScanState extends NormalBleState {
     required this.allowedNames,
   });
 
+  /// Whether [device] is a badge this scan should connect to.
+  ///
+  /// Two independent questions, deliberately kept apart:
+  ///
+  /// 1. Does it look like a badge at all? Satisfied by the advertised service
+  ///    UUID **or** the advertised name. These are OR'd because OEM firmware
+  ///    advertises no service UUIDs, while the open firmware's name is
+  ///    user-changeable - requiring both would exclude one or the other.
+  /// 2. Does it pass the user's badge-selection setting? Only consulted in
+  ///    [BadgeScanMode.specific], and matched on the full name, lower-cased.
+  bool _isTargetBadge(BleDevice device) {
+    // device.services holds what the advertisement carried, not the full GATT
+    // table, so OEM badges contribute nothing here and rely on the name.
+    final looksLikeBadge = device.services.contains(targetServiceUuid) ||
+        matchesBadgeName(device.name);
+
+    if (!looksLikeBadge) return false;
+    if (mode == BadgeScanMode.any) return true;
+
+    final deviceName = (device.name ?? '').trim().toLowerCase();
+    return allowedNames
+        .map((e) => e.trim().toLowerCase())
+        .where((e) => e.isNotEmpty)
+        .contains(deviceName);
+  }
+
   @override
   Future<BleState?> processState() async {
     manager.clearConnectedDevice();
@@ -36,24 +62,7 @@ class ScanState extends NormalBleState {
           if (isCompleted) return;
 
           try {
-            final normalizedAllowedNames = allowedNames
-                .map((e) => e.trim().toLowerCase())
-                .where((e) => e.isNotEmpty)
-                .toList();
-
-            // device.services here is what was in the advertisement, not the
-            // full GATT table. OEM badges advertise no service UUIDs at all,
-            // so this alone rejects them - match the advertised name too.
-            final matchesUuid = device.services.contains(targetServiceUuid);
-            final rawName = (device.name ?? "").trim();
-            final matchesBadgeName =
-                badgeNamePrefixes.any((prefix) => rawName.startsWith(prefix));
-
-            final deviceName = rawName.toLowerCase();
-            final matchesName = mode == BadgeScanMode.any ||
-                normalizedAllowedNames.contains(deviceName);
-
-            if ((matchesUuid || matchesBadgeName) && matchesName) {
+            if (_isTargetBadge(device)) {
               isCompleted = true;
               timeoutTimer?.cancel();
               await UniversalBle.stopScan();

--- a/lib/globals/globals.dart
+++ b/lib/globals/globals.dart
@@ -4,3 +4,19 @@ final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
 final String serviceUuid = "0000fee0-0000-1000-8000-00805f9b34fb";
 final String characteristicUuid = "0000fee1-0000-1000-8000-00805f9b34fb";
+
+/// Advertised-name prefixes that identify a badge.
+///
+/// The OEM firmware advertises as "LSLED" but does **not** put 0xFEE0 in its
+/// advertisement packet - the service is only visible after connecting. So a
+/// scan filtered purely on [serviceUuid] never reports it, and the app reports
+/// "Device not found" for a badge that is sitting right there. The stock vendor
+/// app scans unfiltered and matches the name prefix "LS" instead.
+///
+/// These are matched with a case-sensitive `startsWith`, OR'd against the
+/// service-UUID match, so open firmware (which does advertise 0xFEE0, and whose
+/// name is user-changeable) keeps working unchanged.
+const List<String> badgeNamePrefixes = <String>[
+  'LS', // OEM firmware, e.g. "LSLED"
+  'LED Badge Magic', // open firmware default name
+];

--- a/lib/globals/globals.dart
+++ b/lib/globals/globals.dart
@@ -10,13 +10,34 @@ final String characteristicUuid = "0000fee1-0000-1000-8000-00805f9b34fb";
 /// The OEM firmware advertises as "LSLED" but does **not** put 0xFEE0 in its
 /// advertisement packet - the service is only visible after connecting. So a
 /// scan filtered purely on [serviceUuid] never reports it, and the app reports
-/// "Device not found" for a badge that is sitting right there. The stock vendor
-/// app scans unfiltered and matches the name prefix "LS" instead.
+/// "Device not found" for a badge that is sitting right there.
 ///
-/// These are matched with a case-sensitive `startsWith`, OR'd against the
-/// service-UUID match, so open firmware (which does advertise 0xFEE0, and whose
-/// name is user-changeable) keeps working unchanged.
+/// Kept deliberately narrow. The stock vendor app matches any name *containing*
+/// "LS", but a false positive here is not free: [ScanState] stops scanning on
+/// the first match and hands the device to the connect step, so latching onto
+/// an unrelated device fails the whole transfer rather than skipping past it.
+/// "LSLED" is the name observed on OEM hardware; because matching is by prefix,
+/// suffixed variants such as "LSLED-1234" are still covered. Additional OEM
+/// names can be appended here as they are reported.
+///
+/// Matching is case-sensitive by necessity, not by preference: these prefixes
+/// are also handed to `universal_ble` as a `ScanFilter.withNamePrefix`, and both
+/// its Dart and Kotlin matchers use a case-sensitive `startsWith`. A device
+/// whose name differed only in case would be dropped by that filter before ever
+/// reaching this app's callback, so folding case here would suggest a tolerance
+/// the scan pipeline does not actually have.
 const List<String> badgeNamePrefixes = <String>[
-  'LS', // OEM firmware, e.g. "LSLED"
+  'LSLED', // OEM firmware
   'LED Badge Magic', // open firmware default name
 ];
+
+/// Whether [deviceName] identifies a badge by its advertised name.
+///
+/// Centralised so the scan filter and the scan callback cannot drift apart:
+/// both must agree on trimming and case, or a device the filter admits gets
+/// rejected by the callback (or vice versa).
+bool matchesBadgeName(String? deviceName) {
+  final name = (deviceName ?? '').trim();
+  if (name.isEmpty) return false;
+  return badgeNamePrefixes.any(name.startsWith);
+}


### PR DESCRIPTION
Fixes #1827

## Changes

Badges running the **OEM firmware** (BLE name `LSLED`) were never discovered — scanning always ended in `Device not found.` after the 15 s timeout, even with the badge powered on, in range, and working correctly with the stock vendor app. Badges flashed with the open `badgemagic-firmware` were unaffected, which makes this easy to miss during development.

### Root cause

The OEM firmware does **not** include `0xFEE0` in its *advertisement packet* — the service only becomes visible after connecting. Discovery was gated on that UUID in two independent places, and both rejected the badge:

- `startScan(scanFilter: ScanFilter(withServices: [serviceUuid]))` — this is pushed down to the **native** scanner, so the device was filtered out before it ever reached Dart.
- `device.services.contains(targetServiceUuid)` in the scan callback — `device.services` on a scan result holds the *advertised* service list, not the GATT table, so it would have dropped the device even if a result had got through.

### Fix

- Added `badgeNamePrefixes` to `lib/globals/globals.dart`, next to the existing `serviceUuid` / `characteristicUuid` constants so the BLE identifiers stay together.
- Passed `withNamePrefix: badgeNamePrefixes` to `ScanFilter`. This is what makes the change small: setting it switches `universal_ble` into custom-filter mode, where the list handed to the native scanner is **empty** (an unfiltered scan) and matching moves into the plugin, with the filter kinds OR'd together.

  ```kotlin
  // UniversalBlePlugin.kt
  val usesCustomFilters = filter?.usesCustomFilters() ?: false   // true iff withNamePrefix is set
  if (usesCustomFilters) {
      universalBleFilterUtil.scanFilter = filter
  } else {
      scanFilters = filter?.toScanFilters(filterServices)
  }
  safeScanner.startScan(scanFilters, settings, scanCallback)
  ```

  OR semantics confirmed at `UniversalBleFilterUtil.kt:37` and mirrored in Dart at `universal_ble_filter_util.dart:61`.
- Changed the callback gate from `matchesUuid && matchesName` to `(matchesUuid || matchesBadgeName) && matchesName`.

Open firmware still matches on `0xFEE0` exactly as before, so nothing regresses for flashed badges, and the separate `BadgeScanMode.specific` name gate is left untouched.

### Reference implementation

The stock vendor app (`Bluetooth LED Name Badge` 3.5.1) scans with an **empty** `ScanFilter` and matches on the name instead:

```java
// com/yannis/ledcard/ble/BLEScanner.java
this.mScanFilter = new ScanFilter.Builder().build();
...
if (!TextUtils.isEmpty(name) && name.contains(BleDevice.DEVICE_NAME)) { ... }

// com/yannis/ledcard/ble/BleDevice.java
public static final String DEVICE_NAME = "LS";
```

Its `fee0`/`fee1` write UUIDs are identical to this app's, so discovery was the only difference. Full details in #1827.

## Screenshots / Recordings

> N/A — no UI change.

## Testing

- `flutter analyze` on both changed files: **No issues found!**
- `dart format --set-exit-if-changed`: clean, 0 files changed
- `flutter test`: **All tests passed!** (22 tests)
- Root cause independently confirmed by a `bleak` scan of the badge (`fee0`/`fee1` present in the GATT table, absent from the advertisement) and by decompiling the vendor app

Note for reviewers: the change is verified by static analysis and against the vendor app's behaviour, but I have not yet been able to confirm end-to-end discovery on a physical OEM badge with this build installed. Independent confirmation from anyone holding an `LSLED` badge would be welcome.

**Checklist**:
- [x] **No hard coding**: the new name prefixes are a named constant in `globals.dart`, placed with the existing BLE UUID constants rather than inlined at the call site.
- [x] **No end of file edits**: no resource files modified.
- [x] **Code reformatting**: `dart format` reports no changes needed.
- [x] **Code analyzation**: `flutter analyze` passes on both files.

## Summary by Sourcery

Relax badge discovery to match OEM firmware badges that do not advertise the FEE0 service UUID while preserving behaviour for open firmware badges.

Bug Fixes:
- Ensure OEM LSLED badges are discoverable by scanning based on name prefixes when FEE0 is absent from advertisements.

Enhancements:
- Centralize badge advertised-name prefixes alongside existing BLE UUID globals for consistent identification.
- Broaden BLE scan filtering to combine service-UUID and name-prefix matching so both OEM and open firmware badges are handled uniformly.