### PR TITLE
fix: fix BLE transfer bug

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -764,8 +764,8 @@ class _HomeScreenState extends State<HomeScreen>
     );
   }
 
-  void _showBleTransferDialog(
-      BuildContext context, InlineImageProvider inlineImageProvider) {
+  Future<void> _showBleTransferDialog(
+      BuildContext context, InlineImageProvider inlineImageProvider) async {
     final bleDialogController = GetIt.instance<BleDialogController>();
     final l10n = GetIt.instance.get<LocalizationService>().l10n;
     bleDialogController.update(
@@ -798,25 +798,26 @@ class _HomeScreenState extends State<HomeScreen>
       },
     );
 
-    animationProvider
-        .handleAnimationTransfer(
-      badgeData: badgeData,
-      inlineImageProvider: inlineImageProvider,
-      speedDialProvider: speedDialProvider,
-      flash: animationProvider.isEffectActive(FlashEffect()),
-      marquee: animationProvider.isEffectActive(MarqueeEffect()),
-      invert: animationProvider.isEffectActive(InvertLEDEffect()),
-      context: context,
-    )
-        .catchError((error) {
+    try {
+      await animationProvider.handleAnimationTransfer(
+        badgeData: badgeData,
+        inlineImageProvider: inlineImageProvider,
+        speedDialProvider: speedDialProvider,
+        flash: animationProvider.isEffectActive(FlashEffect()),
+        marquee: animationProvider.isEffectActive(MarqueeEffect()),
+        invert: animationProvider.isEffectActive(InvertLEDEffect()),
+        context: context,
+      );
+    } catch (error) {
       bleDialogController.update(
         BleDialogStatus.error,
         "An unexpected error\noccurred.",
       );
-      Future.delayed(const Duration(milliseconds: 2000), () {
-        if (context.mounted) Navigator.of(context).pop();
-      });
-    });
+      await Future.delayed(const Duration(milliseconds: 2000));
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
+    }
   }
 
   void _debouncedSavePreferences() {


### PR DESCRIPTION
Fixes #1842 

## Changes 
- The transfer is now asynchronous and the app waits for it to execute before continuing, ensuring correct transfer of heavier animations, such as pacman.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Fix BLE transfer flow by awaiting animation transfer completion and handling errors with a consistent dialog timeout.