### PR TITLE
refactor: centralize UI colors into theme/color.dart

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,28 +1,12 @@
-import 'dart:ui';
-
 import 'package:badgemagic/badgemagic_module/utils/toast_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+export 'package:badgemagic/theme/color.dart';
 
 const homeScreenTitleKey = "bm_hm_title";
 const drawBadgeScreen = "bm_db_screen";
 const savedClipartScreen = "bm_sc_screen";
 const savedBadgeScreen = "bm_sb_screen";
-
-//Colors used in the app
-// Primary Colors
-const Color colorPrimary = Color(0xFFD32F2F);
-const Color colorPrimaryDark = Color(0xFFC72C2C);
-const Color colorAccent = Color(0xFFD32F2F);
-
-// Knob Colors
-const Color backCircleColor = Color(0xFFEDEDED);
-const Color indicatorColor = Color(0xFFD32F2F);
-const Color progressSecondaryColor = Color(0xFFEEEEEE);
-
-// Additional Colors
-const Color mdGrey400 = Color(0xFFBDBDBD);
-const Color dividerColor = Color(0xFFE0E0E0);
-const Color drawerHeaderTitle = Color(0xFFFFFFFF);
 
 //path to all the animation assets used
 const String aniSplitting = 'assets/animations/ic_anim_animation.gif';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/providers/animation_badge_provider.dart';
 import 'package:badgemagic/providers/font_provider.dart';
 import 'package:badgemagic/providers/BadgeScanProvider.dart';
@@ -113,11 +114,11 @@ class MyApp extends StatelessWidget {
               scaffoldMessengerKey: globals.scaffoldMessengerKey,
               debugShowCheckedModeBanner: false,
               theme: ThemeData(
-                colorSchemeSeed: Colors.white,
+                colorSchemeSeed: colorSurface,
                 useMaterial3: true,
                 dialogTheme: DialogThemeData(
-                  backgroundColor: Colors.white,
-                  surfaceTintColor: Colors.transparent,
+                  backgroundColor: colorSurface,
+                  surfaceTintColor: colorTransparent,
                   elevation: 0,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(28.0),
@@ -127,12 +128,12 @@ class MyApp extends StatelessWidget {
                   titleTextStyle: const TextStyle(
                     fontWeight: FontWeight.bold,
                     fontSize: 18,
-                    color: Colors.black,
+                    color: colorOnSurface,
                   ),
                 ),
                 textButtonTheme: TextButtonThemeData(
                   style: TextButton.styleFrom(
-                    foregroundColor: Colors.red,
+                    foregroundColor: colorError,
                     textStyle: const TextStyle(fontWeight: FontWeight.bold),
                     padding: const EdgeInsets.all(15),
                   ),

--- a/lib/theme/color.dart
+++ b/lib/theme/color.dart
@@ -1,0 +1,35 @@
+import 'dart:ui';
+
+const Color colorPrimary = Color(0xFFD32F2F);
+const Color colorPrimaryDark = Color(0xFFC72C2C);
+const Color colorAccent = Color(0xFFD32F2F);
+
+const Color colorSurface = Color(0xFFFFFFFF);
+const Color colorSurfaceSubtle = Color(0xFFF5F5F5);
+const Color colorSurfaceMuted = Color(0xFFEEEEEE);
+const Color colorTransparent = Color(0x00000000);
+
+const Color colorOnSurface = Color(0xFF000000);
+const Color colorOnPrimary = Color(0xFFFFFFFF);
+const Color colorTextStrong = Color(0xDD000000);
+const Color colorTextMuted = Color(0x8A000000);
+const Color colorTextSecondary = Color(0xFF9E9E9E);
+const Color colorNeutralDark = Color(0xFF616161);
+
+const Color colorError = Color(0xFFF44336);
+
+const Color colorSelected = Color(0xFF2196F3);
+const Color colorSelectedSurface = Color(0xFFE3F2FD);
+const Color colorLink = Color(0xFF2196F3);
+const Color colorDisabled = Color(0xFF9E9E9E);
+const Color colorShadow = Color(0xFF9E9E9E);
+
+const Color colorBorder = Color(0xFFE0E0E0);
+
+const Color backCircleColor = Color(0xFFEDEDED);
+const Color indicatorColor = Color(0xFFD32F2F);
+const Color progressSecondaryColor = Color(0xFFEEEEEE);
+
+const Color mdGrey400 = Color(0xFFBDBDBD);
+const Color dividerColor = Color(0xFFE0E0E0);
+const Color drawerHeaderTitle = Color(0xFFFFFFFF);

--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -42,11 +42,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
             children: [
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorSurface,
                   borderRadius: BorderRadius.circular(10),
                   boxShadow: const [
                     BoxShadow(
-                      color: Colors.grey,
+                      color: colorShadow,
                       offset: Offset(0, 1),
                       blurRadius: 2.0,
                     ),
@@ -73,7 +73,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           wordSpacing: 3,
                           fontWeight: FontWeight.w400,
-                          color: Colors.black,
+                          color: colorOnSurface,
                           fontSize: 12,
                         ),
                         softWrap: true,
@@ -87,7 +87,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                               l10n.developedBy,
                               style: GoogleFonts.sora(
                                 fontWeight: FontWeight.w500,
-                                color: Colors.grey,
+                                color: colorTextSecondary,
                               ),
                               overflow: TextOverflow.ellipsis,
                             ),
@@ -101,7 +101,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                                 l10n.fossasiaContributors,
                                 style: GoogleFonts.sora(
                                   fontWeight: FontWeight.w500,
-                                  color: Colors.red,
+                                  color: colorPrimary,
                                   decoration: TextDecoration.underline,
                                 ),
                                 overflow: TextOverflow.ellipsis,
@@ -117,11 +117,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
               SizedBox(height: 10),
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorSurface,
                   boxShadow: [
                     BoxShadow(
                       blurRadius: 1,
-                      color: Colors.grey,
+                      color: colorShadow,
                       offset: Offset(0, 1),
                     )
                   ],
@@ -137,7 +137,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorTextSecondary,
                         ),
                       ),
                     ),
@@ -152,7 +152,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.black,
+                          color: colorOnSurface,
                         ),
                       ),
                       subtitle: Text(
@@ -160,7 +160,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorTextSecondary,
                         ),
                         softWrap: true,
                       ),
@@ -173,11 +173,11 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
               SizedBox(height: 10),
               Container(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorSurface,
                   boxShadow: [
                     BoxShadow(
                       blurRadius: 1,
-                      color: Colors.grey,
+                      color: colorShadow,
                       offset: Offset(0, 1),
                     )
                   ],
@@ -193,7 +193,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 18,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorTextSecondary,
                         ),
                       ),
                     ),
@@ -208,7 +208,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.black,
+                          color: colorOnSurface,
                         ),
                       ),
                       subtitle: Text(
@@ -216,7 +216,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorTextSecondary,
                         ),
                         softWrap: true,
                       ),
@@ -227,14 +227,14 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                       leading: const Icon(
                         Icons.description_outlined,
                         size: 38,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       title: Text(
                         l10n.openSourceLicenses,
                         style: GoogleFonts.sora(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.black,
+                          color: colorOnSurface,
                         ),
                       ),
                       subtitle: Text(
@@ -242,7 +242,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
-                          color: Colors.grey,
+                          color: colorTextSecondary,
                         ),
                         softWrap: true,
                       ),

--- a/lib/view/badgeScanSettingsWidget.dart
+++ b/lib/view/badgeScanSettingsWidget.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/providers/BadgeScanProvider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -133,8 +134,8 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                             label: Text(
                                 'Remove (${provider.selectedIndices.length})'),
                             style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.red,
-                              foregroundColor: Colors.white,
+                              backgroundColor: colorError,
+                              foregroundColor: colorOnPrimary,
                             ),
                           ),
                       ],
@@ -152,14 +153,13 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                             horizontal: 12.0, vertical: 4.0),
                         decoration: BoxDecoration(
                           border: Border.all(
-                            color:
-                                isSelected ? Colors.blue : Colors.grey.shade300,
+                            color: isSelected ? colorSelected : colorBorder,
                             width: isSelected ? 2 : 1,
                           ),
                           borderRadius: BorderRadius.circular(8),
                           color: isSelected
-                              ? Colors.blue.shade50
-                              : Colors.transparent,
+                              ? colorSelectedSurface
+                              : colorTransparent,
                         ),
                         child: Row(
                           children: [
@@ -167,7 +167,7 @@ class _BadgeScanSettingsWidgetState extends State<BadgeScanSettingsWidget> {
                               value: isSelected,
                               onChanged: (value) =>
                                   provider.toggleSelection(index),
-                              activeColor: Colors.blue,
+                              activeColor: colorSelected,
                             ),
                             Expanded(
                               child: Padding(

--- a/lib/view/draw_badge_screen.dart
+++ b/lib/view/draw_badge_screen.dart
@@ -308,7 +308,7 @@ class _DrawBadgeState extends State<DrawBadge> {
       double iconSize, double fontSize, double height,
       {String? iconAsset}) {
     final isSelected = drawToggle.isDrawing == isDraw;
-    final tint = isSelected ? colorPrimary : Colors.black;
+    final tint = isSelected ? colorPrimary : colorOnSurface;
 
     return TextButton(
       onPressed: () {
@@ -357,10 +357,10 @@ class _DrawBadgeState extends State<DrawBadge> {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.refresh, color: Colors.black, size: iconSize),
+          Icon(Icons.refresh, color: colorOnSurface, size: iconSize),
           const SizedBox(height: 4),
           Text(GetIt.instance.get<LocalizationService>().l10n.reset,
-              style: TextStyle(color: Colors.black, fontSize: fontSize),
+              style: TextStyle(color: colorOnSurface, fontSize: fontSize),
               maxLines: 1,
               overflow: TextOverflow.ellipsis),
         ],
@@ -421,10 +421,10 @@ class _DrawBadgeState extends State<DrawBadge> {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.save, color: Colors.black, size: iconSize),
+          Icon(Icons.save, color: colorOnSurface, size: iconSize),
           const SizedBox(height: 4),
           Text(GetIt.instance.get<LocalizationService>().l10n.save,
-              style: TextStyle(color: Colors.black, fontSize: fontSize),
+              style: TextStyle(color: colorOnSurface, fontSize: fontSize),
               maxLines: 1,
               overflow: TextOverflow.ellipsis),
         ],
@@ -454,12 +454,12 @@ class _DrawBadgeState extends State<DrawBadge> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(Icons.category,
-              color: _showShapeOptions ? colorPrimary : Colors.black,
+              color: _showShapeOptions ? colorPrimary : colorOnSurface,
               size: iconSize),
           const SizedBox(height: 4),
           Text('Shapes',
               style: TextStyle(
-                  color: _showShapeOptions ? colorPrimary : Colors.black,
+                  color: _showShapeOptions ? colorPrimary : colorOnSurface,
                   fontSize: fontSize),
               maxLines: 1,
               overflow: TextOverflow.ellipsis),
@@ -473,7 +473,7 @@ class _DrawBadgeState extends State<DrawBadge> {
       animation: drawToggle,
       builder: (context, _) {
         final bool canUndo = drawToggle.canUndo;
-        final Color buttonColor = canUndo ? Colors.black : Colors.grey;
+        final Color buttonColor = canUndo ? colorOnSurface : colorDisabled;
 
         return TextButton(
           onPressed: canUndo ? () => drawToggle.undo() : null,
@@ -503,7 +503,7 @@ class _DrawBadgeState extends State<DrawBadge> {
       animation: drawToggle,
       builder: (context, _) {
         final bool canRedo = drawToggle.canRedo;
-        final Color buttonColor = canRedo ? Colors.black : Colors.grey;
+        final Color buttonColor = canRedo ? colorOnSurface : colorDisabled;
 
         return TextButton(
           onPressed: canRedo ? drawToggle.redo : null,
@@ -545,11 +545,10 @@ class _DrawBadgeState extends State<DrawBadge> {
         });
       },
       style: ElevatedButton.styleFrom(
-        foregroundColor: isSelected ? Colors.white : Colors.black,
-        backgroundColor: isSelected ? colorPrimary : Colors.white,
+        foregroundColor: isSelected ? colorOnPrimary : colorOnSurface,
+        backgroundColor: isSelected ? colorPrimary : colorSurface,
         elevation: isSelected ? 2 : 1,
-        side:
-            BorderSide(color: isSelected ? colorPrimary : Colors.grey.shade300),
+        side: BorderSide(color: isSelected ? colorPrimary : colorBorder),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
         minimumSize: const Size(55, 40),

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -378,10 +378,10 @@ class _HomeScreenState extends State<HomeScreen>
                                         Size(180, 0)),
                                     backgroundColor:
                                         const WidgetStatePropertyAll(
-                                            Colors.white),
+                                            colorSurface),
                                     surfaceTintColor:
                                         const WidgetStatePropertyAll(
-                                            Colors.white),
+                                            colorSurface),
                                     elevation: const WidgetStatePropertyAll(6),
                                     padding: WidgetStatePropertyAll(
                                       EdgeInsets.symmetric(vertical: 6.h),
@@ -426,7 +426,7 @@ class _HomeScreenState extends State<HomeScreen>
                                             fontSize: 14,
                                             color: selected
                                                 ? colorPrimary
-                                                : Colors.black87,
+                                                : colorTextStrong,
                                             fontWeight: selected
                                                 ? FontWeight.w600
                                                 : FontWeight.normal,
@@ -490,7 +490,7 @@ class _HomeScreenState extends State<HomeScreen>
                         height: isPrefixIconClicked ? 200.h : 0,
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(10.r),
-                          color: Colors.grey[200],
+                          color: colorSurfaceMuted,
                         ),
                         margin: EdgeInsets.symmetric(
                             horizontal: 15.w, vertical: 8.h),
@@ -512,13 +512,13 @@ class _HomeScreenState extends State<HomeScreen>
                     margin: EdgeInsets.fromLTRB(8.w, 8.h, 8.w, 4.h),
                     padding: EdgeInsets.all(4.w),
                     decoration: BoxDecoration(
-                      color: Colors.grey[100],
+                      color: colorSurfaceSubtle,
                       borderRadius: BorderRadius.circular(30.r),
                     ),
                     child: TabBar(
                       isScrollable: false,
                       indicatorSize: TabBarIndicatorSize.tab,
-                      dividerColor: Colors.transparent,
+                      dividerColor: colorTransparent,
                       indicator: BoxDecoration(
                         color: colorPrimary,
                         borderRadius: BorderRadius.circular(30.r),
@@ -533,11 +533,11 @@ class _HomeScreenState extends State<HomeScreen>
                         fontSize: 14.sp,
                         fontWeight: FontWeight.w500,
                       ),
-                      labelColor: Colors.white,
+                      labelColor: colorOnPrimary,
                       unselectedLabelColor: mdGrey400,
                       controller: _tabController,
                       splashFactory: InkRipple.splashFactory,
-                      overlayColor: WidgetStateProperty.all(Colors.transparent),
+                      overlayColor: WidgetStateProperty.all(colorTransparent),
                       labelPadding: EdgeInsets.symmetric(
                         horizontal: 4.w,
                         vertical: layoutConstraints.maxWidth < 600 ? 1.h : 2.h,
@@ -587,8 +587,8 @@ class _HomeScreenState extends State<HomeScreen>
                       child: FilledButton.tonal(
                         onPressed: onTap,
                         style: FilledButton.styleFrom(
-                          backgroundColor: Colors.grey[200],
-                          foregroundColor: Colors.black87,
+                          backgroundColor: colorSurfaceMuted,
+                          foregroundColor: colorTextStrong,
                           elevation: 0,
                           textStyle: TextStyle(
                             fontSize: 14.sp,
@@ -690,7 +690,7 @@ class _HomeScreenState extends State<HomeScreen>
                         margin: EdgeInsets.fromLTRB(12.w, 8.h, 12.w, 12.h),
                         clipBehavior: Clip.antiAlias,
                         decoration: BoxDecoration(
-                          color: Colors.white,
+                          color: colorSurface,
                           borderRadius: BorderRadius.circular(20.r),
                           border: Border.all(color: const Color(0xFFEDEDED)),
                           boxShadow: const [

--- a/lib/view/qr_scan_screen.dart
+++ b/lib/view/qr_scan_screen.dart
@@ -1,5 +1,6 @@
 import 'package:badgemagic/badgemagic_module/utils/qr_code_helper.dart';
 import 'package:badgemagic/badgemagic_module/utils/toast_utils.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/l10n/app_localizations.dart';
 import 'package:badgemagic/services/localization_service.dart';
 import 'package:file_picker/file_picker.dart';
@@ -101,7 +102,7 @@ class _QrScanScreenState extends State<QrScanScreen> {
             width: 240,
             height: 240,
             decoration: BoxDecoration(
-              border: Border.all(color: Colors.white, width: 3),
+              border: Border.all(color: colorOnPrimary, width: 3),
               borderRadius: BorderRadius.circular(12),
             ),
           ),
@@ -115,7 +116,7 @@ class _QrScanScreenState extends State<QrScanScreen> {
                 Text(
                   l10n.scanQrInstruction,
                   textAlign: TextAlign.center,
-                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  style: const TextStyle(color: colorOnPrimary, fontSize: 14),
                 ),
                 const SizedBox(height: 16),
                 ElevatedButton.icon(

--- a/lib/view/save_badge_screen.dart
+++ b/lib/view/save_badge_screen.dart
@@ -172,7 +172,7 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                           onPressed: () => Navigator.pop(context, true),
                           child: Text(
                             l10n.delete,
-                            style: const TextStyle(color: Colors.red),
+                            style: const TextStyle(color: colorError),
                           ),
                         ),
                       ],
@@ -221,14 +221,14 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                     Text(
                       'No saved badges !',
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorOnSurface,
                         fontSize: 20.sp,
                       ),
                     ),
                     Text(
                       'Looks like there are no saved badges yet.',
                       style: TextStyle(
-                        color: Colors.black,
+                        color: colorOnSurface,
                         fontSize: 14.sp,
                       ),
                     ),
@@ -322,7 +322,7 @@ class _SaveBadgeScreenState extends State<SaveBadgeScreen> {
                               child: Text(
                                 l10n.transferButton,
                                 style: const TextStyle(
-                                  color: Colors.white,
+                                  color: colorOnPrimary,
                                   fontSize: 16.0,
                                   fontWeight: FontWeight.w500,
                                 ),

--- a/lib/view/saved_clipart.dart
+++ b/lib/view/saved_clipart.dart
@@ -73,14 +73,14 @@ class _SavedClipartState extends State<SavedClipart> {
                   Text(
                     l10n.noSavedClipart,
                     style: TextStyle(
-                      color: Colors.black,
+                      color: colorOnSurface,
                       fontSize: 20.sp,
                     ),
                   ),
                   Text(
                     l10n.noSavedClipartMessage,
                     style: TextStyle(
-                      color: Colors.black,
+                      color: colorOnSurface,
                       fontSize: 14.sp,
                     ),
                   ),

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -171,8 +171,8 @@ class SettingsScreenState extends State<SettingsScreen> {
                               label: Text(
                                   'Remove (${provider.selectedIndices.length})'),
                               style: ElevatedButton.styleFrom(
-                                backgroundColor: Colors.red,
-                                foregroundColor: Colors.white,
+                                backgroundColor: colorError,
+                                foregroundColor: colorOnPrimary,
                               ),
                             ),
                         ],
@@ -188,14 +188,13 @@ class SettingsScreenState extends State<SettingsScreen> {
                       margin: const EdgeInsets.symmetric(vertical: 4),
                       decoration: BoxDecoration(
                         border: Border.all(
-                          color:
-                              isSelected ? Colors.blue : Colors.grey.shade300,
+                          color: isSelected ? colorSelected : colorBorder,
                           width: isSelected ? 2 : 1,
                         ),
                         borderRadius: BorderRadius.circular(8),
                         color: isSelected
-                            ? Colors.blue.shade50
-                            : Colors.transparent,
+                            ? colorSelectedSurface
+                            : colorTransparent,
                       ),
                       child: Row(
                         children: [
@@ -203,7 +202,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                             value: isSelected,
                             onChanged: (value) =>
                                 provider.toggleSelection(index),
-                            activeColor: Colors.blue,
+                            activeColor: colorSelected,
                           ),
                           Expanded(
                             child: Padding(
@@ -259,7 +258,7 @@ class SettingsScreenState extends State<SettingsScreen> {
                       child: Text(
                         l10n.saveSettings,
                         style: const TextStyle(
-                          color: Colors.black,
+                          color: colorOnSurface,
                         ),
                       ),
                     ),

--- a/lib/view/widgets/about_us_daialog.dart
+++ b/lib/view/widgets/about_us_daialog.dart
@@ -30,7 +30,7 @@ class LicenseDialogContainer extends StatelessWidget {
               style: GoogleFonts.sora(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Colors.black,
+                color: colorOnSurface,
               ),
             ),
             // SizedBox(
@@ -48,7 +48,7 @@ class LicenseDialogContainer extends StatelessWidget {
                 decoration: TextDecoration.underline,
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Colors.blue,
+                color: colorLink,
               ),
             ),
           ),
@@ -57,7 +57,7 @@ class LicenseDialogContainer extends StatelessWidget {
         Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(4),
-            color: Colors.grey[300],
+            color: colorBorder,
           ),
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 10),
@@ -68,7 +68,7 @@ class LicenseDialogContainer extends StatelessWidget {
                 letterSpacing: 0.6,
                 fontSize: 10,
                 fontWeight: FontWeight.w500,
-                color: Colors.black,
+                color: colorOnSurface,
               ),
             ),
           ),
@@ -84,7 +84,7 @@ void showLicenseDialog(BuildContext context) {
     builder: (BuildContext context) {
       return Dialog(
         insetPadding: EdgeInsets.all(8),
-        backgroundColor: Colors.white,
+        backgroundColor: colorSurface,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8.0),
         ),
@@ -95,7 +95,7 @@ void showLicenseDialog(BuildContext context) {
               Container(
                 padding: const EdgeInsets.only(left: 16.0, top: 16, bottom: 8),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: colorSurface,
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(10.0),
                     topRight: Radius.circular(10.0),
@@ -108,7 +108,7 @@ void showLicenseDialog(BuildContext context) {
                     style: GoogleFonts.inter(
                       fontWeight: FontWeight.w400,
                       fontSize: 20,
-                      color: Colors.black,
+                      color: colorOnSurface,
                     ),
                   ),
                 ),
@@ -222,7 +222,7 @@ void showLicenseDialog(BuildContext context) {
                   onPressed: () => Navigator.of(context).pop(),
                   child: const Text(
                     'CLOSE',
-                    style: TextStyle(color: Colors.red),
+                    style: TextStyle(color: colorError),
                   ),
                 ),
               ),

--- a/lib/view/widgets/animation_container.dart
+++ b/lib/view/widgets/animation_container.dart
@@ -91,7 +91,7 @@ class _AniContainerState extends State<AniContainer> {
           animationCardState.setAnimationMode(badgeAnimation);
         },
         child: Card(
-          surfaceTintColor: Colors.white,
+          surfaceTintColor: colorSurface,
           color: animationCardState.isAnimationActive(badgeAnimation)
               ? colorPrimaryDark
               : drawerHeaderTitle,
@@ -106,7 +106,7 @@ class _AniContainerState extends State<AniContainer> {
                         size: 36,
                         color:
                             animationCardState.isAnimationActive(badgeAnimation)
-                                ? Colors.white
+                                ? colorOnPrimary
                                 : const Color.fromARGB(255, 117, 117, 117),
                       )
                     : (widget.animation != null
@@ -115,7 +115,7 @@ class _AniContainerState extends State<AniContainer> {
                             fit: BoxFit.fill,
                             color: animationCardState
                                     .isAnimationActive(badgeAnimation)
-                                ? Colors.white
+                                ? colorOnPrimary
                                 : null,
                             colorBlendMode: animationCardState
                                     .isAnimationActive(badgeAnimation)
@@ -131,8 +131,8 @@ class _AniContainerState extends State<AniContainer> {
                   style: TextStyle(
                     fontSize: 9.sp,
                     color: animationCardState.isAnimationActive(badgeAnimation)
-                        ? Colors.white
-                        : Colors.black,
+                        ? colorOnPrimary
+                        : colorOnSurface,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,

--- a/lib/view/widgets/badge_delete_dialog.dart
+++ b/lib/view/widgets/badge_delete_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:badgemagic/services/localization_service.dart';
@@ -24,7 +25,7 @@ class DeleteBadgeDialog extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  Icon(Icons.delete, color: Colors.black),
+                  Icon(Icons.delete, color: colorOnSurface),
                   SizedBox(width: 10.w),
                   Text(l10n.delete,
                       style: TextStyle(
@@ -45,13 +46,13 @@ class DeleteBadgeDialog extends StatelessWidget {
                         Navigator.of(context).pop(false);
                       },
                       child: Text(l10n.cancel,
-                          style: const TextStyle(color: Colors.red))),
+                          style: const TextStyle(color: colorError))),
                   TextButton(
                       onPressed: () {
                         Navigator.of(context).pop(true);
                       },
                       child: Text(l10n.ok,
-                          style: const TextStyle(color: Colors.red))),
+                          style: const TextStyle(color: colorError))),
                 ],
               ),
             ],

--- a/lib/view/widgets/ble_progress_dialog.dart
+++ b/lib/view/widgets/ble_progress_dialog.dart
@@ -26,8 +26,8 @@ class BleProgressDialog extends StatelessWidget {
     return PopScope(
         canPop: false,
         child: AlertDialog(
-            backgroundColor: Colors.white,
-            surfaceTintColor: Colors.transparent,
+            backgroundColor: colorSurface,
+            surfaceTintColor: colorTransparent,
             shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(16.r)),
             contentPadding: EdgeInsets.fromLTRB(16.w, 16.h, 16.w, 8.h),
@@ -47,7 +47,7 @@ class BleProgressDialog extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 13.sp,
                       fontWeight: FontWeight.w600,
-                      color: Colors.black87,
+                      color: colorTextStrong,
                     ),
                   ),
                   if (status == BleDialogStatus.transferring) ...[
@@ -56,7 +56,7 @@ class BleProgressDialog extends StatelessWidget {
                       borderRadius: BorderRadius.circular(4.r),
                       child: LinearProgressIndicator(
                         value: progress,
-                        backgroundColor: Colors.grey.shade200,
+                        backgroundColor: colorSurfaceMuted,
                         color: indicatorColor,
                         minHeight: 6.h,
                       ),
@@ -70,7 +70,7 @@ class BleProgressDialog extends StatelessWidget {
               if (isFinished)
                 TextButton(
                   style: TextButton.styleFrom(
-                    foregroundColor: Colors.black,
+                    foregroundColor: colorOnSurface,
                     textStyle:
                         TextStyle(fontSize: 14.sp, fontWeight: FontWeight.bold),
                   ),
@@ -82,7 +82,7 @@ class BleProgressDialog extends StatelessWidget {
               if (!isFinished)
                 TextButton(
                   style: TextButton.styleFrom(
-                    foregroundColor: Colors.black,
+                    foregroundColor: colorOnSurface,
                     textStyle:
                         TextStyle(fontSize: 14.sp, fontWeight: FontWeight.bold),
                   ),
@@ -113,7 +113,7 @@ class BleProgressDialog extends StatelessWidget {
             size: 44, color: colorPrimary);
       case BleDialogStatus.error:
         return const Icon(Icons.error_outline_rounded,
-            size: 44, color: Colors.red);
+            size: 44, color: colorError);
     }
   }
 }

--- a/lib/view/widgets/clipart_list_view.dart
+++ b/lib/view/widgets/clipart_list_view.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:badgemagic/badgemagic_module/utils/file_helper.dart';
 import 'package:badgemagic/badgemagic_module/utils/image_utils.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/view/draw_badge_screen.dart';
 import 'package:badgemagic/view/widgets/badge_delete_dialog.dart';
 import 'package:flutter/material.dart';
@@ -41,11 +42,11 @@ class SavedClipartListView extends StatelessWidget {
           padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
           height: 90.h,
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: colorSurface,
             borderRadius: BorderRadius.circular(15.dg),
             boxShadow: [
               BoxShadow(
-                color: Colors.grey.withOpacity(0.5),
+                color: colorShadow.withOpacity(0.5),
                 spreadRadius: 2,
                 blurRadius: 5,
                 offset: const Offset(0, 3),
@@ -84,8 +85,8 @@ class SavedClipartListView extends StatelessWidget {
               const Spacer(),
               IconButton(
                 style: IconButton.styleFrom(
-                  backgroundColor: Colors.grey.shade100,
-                  foregroundColor: Colors.grey.shade700,
+                  backgroundColor: colorSurfaceSubtle,
+                  foregroundColor: colorNeutralDark,
                   padding: EdgeInsets.all(8.dg),
                 ),
                 onPressed: () {
@@ -103,7 +104,7 @@ class SavedClipartListView extends StatelessWidget {
               ),
               SizedBox(width: 10.w),
               IconButton(
-                icon: const Icon(Icons.share, color: Colors.black),
+                icon: const Icon(Icons.share, color: colorOnSurface),
                 onPressed: () async {
                   await FileHelper().exportClipart(fileName);
                 },
@@ -111,8 +112,8 @@ class SavedClipartListView extends StatelessWidget {
               SizedBox(width: 10.w),
               IconButton(
                 style: IconButton.styleFrom(
-                  backgroundColor: Colors.red,
-                  foregroundColor: Colors.white,
+                  backgroundColor: colorError,
+                  foregroundColor: colorOnPrimary,
                   padding: EdgeInsets.all(8.dg),
                 ),
                 icon: const Icon(Icons.delete_outline_rounded),

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -24,7 +24,7 @@ class CommonScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: scaffoldKey,
-      backgroundColor: Colors.white,
+      backgroundColor: colorSurface,
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         leading: Builder(builder: (context) {
@@ -34,14 +34,14 @@ class CommonScaffold extends StatelessWidget {
             },
             icon: const Icon(
               Icons.menu,
-              color: Colors.white,
+              color: colorOnPrimary,
             ),
           );
         }),
         backgroundColor: colorPrimary,
         title: Text(
           title,
-          style: const TextStyle(color: Colors.white),
+          style: const TextStyle(color: colorOnPrimary),
         ),
         actions: [
           if (actions != null) ...actions!,

--- a/lib/view/widgets/effects_container.dart
+++ b/lib/view/widgets/effects_container.dart
@@ -70,7 +70,7 @@ class _EffectContainerState extends State<EffectContainer> {
           );
         },
         child: Card(
-          surfaceTintColor: Colors.white,
+          surfaceTintColor: colorSurface,
           color: effectCardState.isEffectActive(badgeEffect)
               ? colorAccent
               : drawerHeaderTitle,
@@ -83,7 +83,7 @@ class _EffectContainerState extends State<EffectContainer> {
                   widget.effect,
                   fit: BoxFit.contain,
                   color: effectCardState.isEffectActive(badgeEffect)
-                      ? Colors.white
+                      ? colorOnPrimary
                       : null,
                   colorBlendMode: effectCardState.isEffectActive(badgeEffect)
                       ? BlendMode.srcIn
@@ -97,8 +97,8 @@ class _EffectContainerState extends State<EffectContainer> {
                   style: TextStyle(
                     fontSize: 10.sp,
                     color: effectCardState.isEffectActive(badgeEffect)
-                        ? Colors.white
-                        : Colors.black,
+                        ? colorOnPrimary
+                        : colorOnSurface,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -41,7 +41,7 @@ class _BMDrawerState extends State<BMDrawer> {
             aspectRatio: 16 / 9,
             child: DrawerHeader(
               decoration: BoxDecoration(
-                color: Colors.red,
+                color: colorPrimary,
               ),
               child: Center(
                 child: Text(
@@ -102,7 +102,7 @@ class _BMDrawerState extends State<BMDrawer> {
             child: Text(
               l10n.other,
               style: const TextStyle(
-                color: Colors.black54,
+                color: colorTextMuted,
                 fontWeight: FontWeight.bold,
                 fontSize: 14,
               ),
@@ -164,18 +164,18 @@ class _BMDrawerState extends State<BMDrawer> {
       leading: icon != null
           ? Icon(
               icon,
-              color: currentIndex == index ? colorAccent : Colors.black,
+              color: currentIndex == index ? colorAccent : colorOnSurface,
             )
           : Image.asset(
               assetIcon!,
               height: 18,
-              color: currentIndex == index ? colorAccent : Colors.black,
+              color: currentIndex == index ? colorAccent : colorOnSurface,
             ),
       title: title is String
           ? Text(
               title,
               style: TextStyle(
-                color: currentIndex == index ? colorAccent : Colors.black,
+                color: currentIndex == index ? colorAccent : colorOnSurface,
                 fontWeight: FontWeight.bold,
                 fontSize: 14,
               ),

--- a/lib/view/widgets/qr_share_dialog.dart
+++ b/lib/view/widgets/qr_share_dialog.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 
 import 'package:badgemagic/badgemagic_module/utils/qr_code_helper.dart';
 import 'package:badgemagic/badgemagic_module/utils/toast_utils.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/l10n/app_localizations.dart';
 import 'package:badgemagic/services/localization_service.dart';
 import 'package:flutter/material.dart';
@@ -79,7 +80,7 @@ class _QrShareScreenState extends State<QrShareScreen> {
   Widget build(BuildContext context) {
     final l10n = _l10n;
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: colorSurface,
       appBar: AppBar(
         title: Text(l10n.shareBadgeQrCode),
         actions: [
@@ -114,7 +115,7 @@ class _QrShareScreenState extends State<QrShareScreen> {
               child: Text(
                 l10n.qrShareInstruction,
                 textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 14, color: Colors.black54),
+                style: const TextStyle(fontSize: 14, color: colorTextMuted),
               ),
             ),
           ],

--- a/lib/view/widgets/save_badge_card.dart
+++ b/lib/view/widgets/save_badge_card.dart
@@ -48,11 +48,11 @@ class SaveBadgeCard extends StatelessWidget {
       padding: EdgeInsets.all(6.dg),
       margin: EdgeInsets.all(10.dg),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: colorSurface,
         borderRadius: BorderRadius.circular(6.dg),
         boxShadow: [
           BoxShadow(
-            color: Colors.grey.withValues(alpha: 0.5),
+            color: colorShadow.withValues(alpha: 0.5),
             spreadRadius: 2,
             blurRadius: 5,
             offset: const Offset(0, 3),
@@ -93,7 +93,7 @@ class SaveBadgeCard extends StatelessWidget {
                       icon: Image.asset(
                         "assets/icons/t_play.png",
                         height: 20,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       onPressed: () {
                         provider.savedBadgeAnimation(
@@ -105,7 +105,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.edit,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       onPressed: () async {
                         final navigator = Navigator.of(context);
@@ -128,7 +128,7 @@ class SaveBadgeCard extends StatelessWidget {
                       icon: Image.asset(
                         "assets/icons/t_updown.png",
                         height: 24.h,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       onPressed: () {
                         logger.d("BadgeData: ${badgeData.value}");
@@ -141,7 +141,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.share,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       onPressed: () {
                         _showShareOptions(context);
@@ -150,7 +150,7 @@ class SaveBadgeCard extends StatelessWidget {
                     IconButton(
                       icon: const Icon(
                         Icons.delete,
-                        color: Colors.black,
+                        color: colorOnSurface,
                       ),
                       onPressed: () async {
                         //add a dialog for confirmation before deleting
@@ -202,7 +202,7 @@ class SaveBadgeCard extends StatelessWidget {
                         ),
                         child: Image.asset(
                           "assets/icons/flash.png",
-                          color: Colors.white,
+                          color: colorOnPrimary,
                           height: 14.h,
                         ),
                       ),
@@ -216,7 +216,7 @@ class SaveBadgeCard extends StatelessWidget {
                         ),
                         child: Image.asset(
                           "assets/icons/square.png",
-                          color: Colors.white,
+                          color: colorOnPrimary,
                           height: 14.h,
                         ),
                       ),
@@ -230,7 +230,7 @@ class SaveBadgeCard extends StatelessWidget {
                         ),
                         child: Image.asset(
                           "assets/icons/t_invert.png",
-                          color: Colors.white,
+                          color: colorOnPrimary,
                           height: 14.h,
                         ),
                       ),
@@ -246,7 +246,7 @@ class SaveBadgeCard extends StatelessWidget {
                         children: [
                           Image.asset(
                             "assets/icons/t_double.png",
-                            color: Colors.white,
+                            color: colorOnPrimary,
                             height: 14.h,
                           ),
                           const SizedBox(width: 4),
@@ -257,7 +257,7 @@ class SaveBadgeCard extends StatelessWidget {
                                   .messages[0]
                                   .speed,
                             ).toString(),
-                            style: const TextStyle(color: Colors.white),
+                            style: const TextStyle(color: colorOnPrimary),
                           )
                         ],
                       ),
@@ -278,7 +278,7 @@ class SaveBadgeCard extends StatelessWidget {
                             .split('.')
                             .last
                             .toUpperCase(),
-                        style: const TextStyle(color: Colors.white),
+                        style: const TextStyle(color: colorOnPrimary),
                       ),
                     ),
                   ],

--- a/lib/view/widgets/save_badge_dialog.dart
+++ b/lib/view/widgets/save_badge_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:badgemagic/badgemagic_module/utils/toast_utils.dart';
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/badge_effect/flash_effect.dart';
 import 'package:badgemagic/badge_effect/marquee_effect.dart';
 import 'package:badgemagic/providers/animation_badge_provider.dart';
@@ -65,7 +66,7 @@ class SaveBadgeDialog extends StatelessWidget {
               l10n.badgeName,
               style: const TextStyle(
                 fontWeight: FontWeight.w400,
-                color: Colors.red,
+                color: colorError,
               ),
             ),
             const SizedBox(height: 10),
@@ -75,10 +76,10 @@ class SaveBadgeDialog extends StatelessWidget {
               maxLength: 200,
               decoration: const InputDecoration(
                 enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.red),
+                  borderSide: BorderSide(color: colorError),
                 ),
                 focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Colors.red, width: 2),
+                  borderSide: BorderSide(color: colorError, width: 2),
                 ),
               ),
               buildCounter: (context,
@@ -89,7 +90,7 @@ class SaveBadgeDialog extends StatelessWidget {
                     '$currentLength/${maxLength ?? 0}',
                     style: const TextStyle(
                       fontSize: 12,
-                      color: Colors.grey,
+                      color: colorTextSecondary,
                     ),
                   ),
                 );
@@ -104,7 +105,7 @@ class SaveBadgeDialog extends StatelessWidget {
                     },
                     child: Text(
                       l10n.cancel,
-                      style: const TextStyle(color: Colors.red),
+                      style: const TextStyle(color: colorError),
                     )),
                 TextButton(
                   onPressed: () async {
@@ -263,7 +264,7 @@ class SaveBadgeDialog extends StatelessWidget {
                   },
                   child: Text(
                     'Save',
-                    style: const TextStyle(color: Colors.red),
+                    style: const TextStyle(color: colorError),
                   ),
                 ),
               ],

--- a/lib/view/widgets/special_animation_dialog.dart
+++ b/lib/view/widgets/special_animation_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:badgemagic/constants.dart';
 import 'package:badgemagic/services/localization_service.dart';
 import 'package:get_it/get_it.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +24,8 @@ Future<bool?> showSpecialAnimationDialog(
                   Expanded(
                     child: Text(
                       textToClear,
-                      style: const TextStyle(fontSize: 13, color: Colors.grey),
+                      style: const TextStyle(
+                          fontSize: 13, color: colorTextSecondary),
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),

--- a/lib/view/widgets/vectorview.dart
+++ b/lib/view/widgets/vectorview.dart
@@ -176,8 +176,8 @@ class _VectorGridViewState extends State<VectorGridView> {
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(5),
                   ),
-                  surfaceTintColor: Colors.white,
-                  color: Colors.white,
+                  surfaceTintColor: colorSurface,
+                  color: colorSurface,
                   elevation: 2,
                   child: Center(
                     child: Icon(
@@ -208,11 +208,11 @@ class _VectorGridViewState extends State<VectorGridView> {
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(5),
                   side: isSelected
-                      ? BorderSide(color: Colors.grey.shade500, width: 2)
+                      ? BorderSide(color: colorTextSecondary, width: 2)
                       : BorderSide.none,
                 ),
-                surfaceTintColor: Colors.white,
-                color: isSelected ? Colors.grey.shade300 : Colors.white,
+                surfaceTintColor: colorSurface,
+                color: isSelected ? colorBorder : colorSurface,
                 elevation: isSelected ? 4 : 2,
                 child: Padding(
                   padding: const EdgeInsets.all(2.0),


### PR DESCRIPTION
Fixes #1665 

## Changes 
                                                                                                                                                                                  
  - Added lib/theme/color.dart with a semantic colour palette (colorPrimary, colorSurface, colorOnSurface, colorError, colorSelected, colorBorder, etc.).                          
  - constants.dart re-exports the palette so existing imports keep working.                                                                                                        
  - Replaced all hardcoded Colors.* in the view layer and theme seed with these constants. No behavioural changes.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Centralize UI color definitions into a shared semantic palette and update the app to consistently use those themed colors.

Enhancements:
- Introduce lib/theme/color.dart with a semantic color palette for primary, surface, text, error, selection, and utility colors.
- Have constants.dart re-export the new color palette to preserve existing imports.
- Replace hardcoded Flutter Colors usages across screens, dialogs, widgets, and theming with the shared color constants for visual consistency and easier theming.