### PR TITLE
fix: inconsistent naming

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -160,7 +160,7 @@ class MyApp extends StatelessWidget {
                 '/': (context) => const HomeScreen(),
                 '/drawBadge': (context) => const DrawBadge(),
                 '/savedBadge': (context) => const SaveBadgeScreen(),
-                '/savedClipart': (context) => const SavedClipart(),
+                '/savedClipart': (context) => const SavedClipartScreen(),
                 '/aboutUs': (context) => const AboutUsScreen(),
                 '/settings': (context) => const SettingsScreen(),
               },

--- a/lib/others/badge_text_storage.dart
+++ b/lib/others/badge_text_storage.dart
@@ -6,7 +6,7 @@ import 'package:path_provider/path_provider.dart';
 
 /// A utility class to store and retrieve the original text of badges
 class BadgeTextStorage {
-  static const String TEXT_STORAGE_FILENAME = 'badge_original_texts.json';
+  static const String _textStorageFileName = 'badge_original_texts.json';
 
   /// Save the original text for a badge
   static Future<void> saveOriginalText(
@@ -71,7 +71,7 @@ class BadgeTextStorage {
   static Future<Map<String, String>> _getTextStorage() async {
     try {
       final directory = await getApplicationDocumentsDirectory();
-      final file = File('${directory.path}/$TEXT_STORAGE_FILENAME');
+      final file = File('${directory.path}/$_textStorageFileName');
 
       if (!await file.exists()) {
         await file.create();
@@ -102,7 +102,7 @@ class BadgeTextStorage {
   static Future<void> _saveTextStorage(Map<String, String> textStorage) async {
     try {
       final directory = await getApplicationDocumentsDirectory();
-      final file = File('${directory.path}/$TEXT_STORAGE_FILENAME');
+      final file = File('${directory.path}/$_textStorageFileName');
 
       final jsonString = jsonEncode(textStorage);
       await file.writeAsString(jsonString);

--- a/lib/providers/saved_badge_provider.dart
+++ b/lib/providers/saved_badge_provider.dart
@@ -55,7 +55,7 @@ class SavedBadgeProvider extends ChangeNotifier {
     required String? savedBadgeFilename,
     required AnimationBadgeProvider animationProvider,
     required SpeedDialProvider speedDialProvider,
-    required TextEditingController inlineimagecontroller,
+    required TextEditingController inlineImageController,
     required BuildContext context,
   }) async {
     final fileHelper = FileHelper();
@@ -78,7 +78,7 @@ class SavedBadgeProvider extends ChangeNotifier {
       logger.e("Failed to retrieve original badge text: $e");
       badgeText = "Hello";
     }
-    inlineimagecontroller.text = badgeText;
+    inlineImageController.text = badgeText;
 
     if (message.flash) {
       animationProvider.addEffect(effectMap[1]);

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -61,7 +61,7 @@ class _HomeScreenState extends State<HomeScreen>
   final ImageUtils imageUtils = ImageUtils();
   final InlineImageProvider inlineImageProvider =
       GetIt.instance<InlineImageProvider>();
-  final TextEditingController inlineimagecontroller =
+  final TextEditingController inlineImageController =
       GetIt.instance.get<InlineImageProvider>().getController();
 
   final Converters _converters = Converters();
@@ -84,7 +84,7 @@ class _HomeScreenState extends State<HomeScreen>
     super.initState();
     _vectorScrollController = ScrollController();
     WidgetsBinding.instance.addObserver(this);
-    inlineimagecontroller.addListener(handleTextChange);
+    inlineImageController.addListener(handleTextChange);
     _setPortraitOrientation();
     animationProvider = context.read<AnimationBadgeProvider>();
     speedDialProvider = context.read<SpeedDialProvider>();
@@ -99,7 +99,7 @@ class _HomeScreenState extends State<HomeScreen>
         await _loadBadgeDataFromDisk(widget.savedBadgeFilename!);
       }
 
-      inlineimagecontroller.addListener(_debouncedSavePreferences);
+      inlineImageController.addListener(_debouncedSavePreferences);
       animationProvider.addListener(_debouncedSavePreferences);
       speedDialProvider.addListener(_debouncedSavePreferences);
     });
@@ -114,7 +114,7 @@ class _HomeScreenState extends State<HomeScreen>
     final transition = prefs.getInt(_transitionKey);
     final effects = prefs.getStringList(_effectsKey);
     if (text != null) {
-      inlineimagecontroller.text = text;
+      inlineImageController.text = text;
     }
     if (speed != null) {
       speedDialProvider.setDialValue(speed);
@@ -141,7 +141,7 @@ class _HomeScreenState extends State<HomeScreen>
       }
     }
     animationProvider.badgeAnimation(
-      inlineimagecontroller.text,
+      inlineImageController.text,
       _converters,
       animationProvider.isEffectActive(InvertLEDEffect()),
     );
@@ -149,7 +149,7 @@ class _HomeScreenState extends State<HomeScreen>
 
   Future<void> savePreferences() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_textKey, inlineimagecontroller.text);
+    await prefs.setString(_textKey, inlineImageController.text);
     await prefs.setInt(
       _speedKey,
       speedDialProvider.getOuterValue(),
@@ -176,7 +176,7 @@ class _HomeScreenState extends State<HomeScreen>
       final (badgeText, badgeData, savedData) =
           await BadgeLoaderHelper.loadBadgeDataAndText(badgeFilename);
 
-      inlineimagecontroller.text = badgeText;
+      inlineImageController.text = badgeText;
 
       animationProvider.removeEffect(effectMap[0]);
       animationProvider.removeEffect(effectMap[1]);
@@ -264,8 +264,8 @@ class _HomeScreenState extends State<HomeScreen>
     _debounceTimer?.cancel();
     _vectorScrollController.dispose();
     WidgetsBinding.instance.removeObserver(this);
-    inlineimagecontroller.removeListener(handleTextChange);
-    inlineimagecontroller.removeListener(_debouncedSavePreferences);
+    inlineImageController.removeListener(handleTextChange);
+    inlineImageController.removeListener(_debouncedSavePreferences);
     animationProvider.removeListener(_debouncedSavePreferences);
     speedDialProvider.removeListener(_debouncedSavePreferences);
     _tabController.dispose();
@@ -276,18 +276,18 @@ class _HomeScreenState extends State<HomeScreen>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
-      if (inlineimagecontroller.text.trim().isEmpty &&
+      if (inlineImageController.text.trim().isEmpty &&
           _cachedText.trim().isNotEmpty) {
-        inlineimagecontroller.text = _cachedText;
+        inlineImageController.text = _cachedText;
       }
       animationProvider.badgeAnimation(
-        inlineimagecontroller.text,
+        inlineImageController.text,
         _converters,
         animationProvider.isEffectActive(InvertLEDEffect()),
       );
       if (mounted) setState(() {});
     } else if (state == AppLifecycleState.paused) {
-      _cachedText = inlineimagecontroller.text;
+      _cachedText = inlineImageController.text;
       animationProvider.stopAnimation();
     } else if (state == AppLifecycleState.inactive) {
       animationProvider.stopAnimation();
@@ -328,7 +328,7 @@ class _HomeScreenState extends State<HomeScreen>
                       borderRadius: BorderRadius.circular(10.r),
                       elevation: 4,
                       child: ExtendedTextField(
-                        controller: inlineimagecontroller,
+                        controller: inlineImageController,
                         specialTextSpanBuilder: ImageBuilder(),
                         style: Provider.of<FontProvider>(context)
                                     .selectedFont !=
@@ -403,7 +403,7 @@ class _HomeScreenState extends State<HomeScreen>
                                       onPressed: () {
                                         fontProvider.changeFont(opt);
                                         animationProvider.badgeAnimation(
-                                          inlineimagecontroller.text,
+                                          inlineImageController.text,
                                           _converters,
                                           animationProvider.isEffectActive(
                                               InvertLEDEffect()),
@@ -615,7 +615,7 @@ class _HomeScreenState extends State<HomeScreen>
                               label: l10n.saveButton,
                               primary: false,
                               onTap: () async {
-                                if (inlineimagecontroller.text.trim().isEmpty) {
+                                if (inlineImageController.text.trim().isEmpty) {
                                   ToastUtils()
                                       .showToast("Please enter a message");
                                   return;
@@ -633,7 +633,7 @@ class _HomeScreenState extends State<HomeScreen>
 
                                   await savedBadgeProvider.updateBadgeData(
                                     baseFilename,
-                                    inlineimagecontroller.text,
+                                    inlineImageController.text,
                                     animationProvider
                                         .isEffectActive(FlashEffect()),
                                     animationProvider
@@ -659,7 +659,7 @@ class _HomeScreenState extends State<HomeScreen>
                                       return SaveBadgeDialog(
                                         speed: speedDialProvider,
                                         animationProvider: animationProvider,
-                                        textController: inlineimagecontroller,
+                                        textController: inlineImageController,
                                         isInverse: animationProvider
                                             .isEffectActive(InvertLEDEffect()),
                                       );
@@ -834,7 +834,7 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   void handleTextChange() {
-    final currentText = inlineimagecontroller.text;
+    final currentText = inlineImageController.text;
 
     if (currentText != previousText) {
       if (animationProvider.isSpecialAnimationSelected() &&
@@ -842,7 +842,7 @@ class _HomeScreenState extends State<HomeScreen>
         animationProvider.resetToTextAnimation();
       }
 
-      final selection = inlineimagecontroller.selection;
+      final selection = inlineImageController.selection;
       if (previousText.length > currentText.length) {
         final deletionIndex = selection.baseOffset;
         final regex = RegExp(r'<<\d+>>');
@@ -851,23 +851,23 @@ class _HomeScreenState extends State<HomeScreen>
         bool placeholderDeleted = false;
         for (final match in matches) {
           if (deletionIndex > match.start && deletionIndex < match.end) {
-            inlineimagecontroller.text =
+            inlineImageController.text =
                 previousText.replaceRange(match.start, match.end, '');
-            inlineimagecontroller.selection =
+            inlineImageController.selection =
                 TextSelection.collapsed(offset: match.start);
             placeholderDeleted = true;
             break;
           }
         }
         if (!placeholderDeleted) {
-          previousText = inlineimagecontroller.text;
+          previousText = inlineImageController.text;
         }
       } else {
         previousText = currentText;
       }
 
       animationProvider.badgeAnimation(
-        inlineimagecontroller.text,
+        inlineImageController.text,
         _converters,
         animationProvider.isEffectActive(InvertLEDEffect()),
       );

--- a/lib/view/saved_clipart_screen.dart
+++ b/lib/view/saved_clipart_screen.dart
@@ -11,14 +11,14 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get_it/get_it.dart';
 
-class SavedClipart extends StatefulWidget {
-  const SavedClipart({super.key});
+class SavedClipartScreen extends StatefulWidget {
+  const SavedClipartScreen({super.key});
 
   @override
-  State<SavedClipart> createState() => _SavedClipartState();
+  State<SavedClipartScreen> createState() => _SavedClipartScreenState();
 }
 
-class _SavedClipartState extends State<SavedClipart> {
+class _SavedClipartScreenState extends State<SavedClipartScreen> {
   InlineImageProvider imageprovider = GetIt.instance<InlineImageProvider>();
   FileHelper file = FileHelper();
 


### PR DESCRIPTION
Fixes #1856 

⚠️ Please merge in order
This is PR 4 in the codebase cleanup (https://github.com/fossasia/badgemagic-app/issues/1852). These PRs are dependent and must be merged sequentially, each one builds on the previous, so merging out of order will break the later PRs.

## Changes 
Renames fields, a class, and a constant to follow Dart naming conventions and match the rest of the codebase:
- `inlineimagecontroller` → `inlineImageController` (camelCase field)
- `SavedClipart` → `SavedClipartScreen` (matches other screen classes)
- `TEXT_STORAGE_FILENAME` → `_textStorageFileName` (camelCase constant; also clears an analyzer info)

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Refactor badge magic codebase to standardize naming, reorganize modules, and introduce a reusable animated badge widget.

Enhancements:
- Rename multiple providers, screens, widgets, animations, effects, and utility modules to clearer, Dart-idiomatic names and reorganize them under consolidated namespaces such as `models`, `others`, `communication`, and `view/widgets`.
- Simplify several animation and utility implementations by removing redundant comments and dead code while preserving behavior.
- Adjust animation speed strategy and special animation handling to differentiate between text animations and custom icon/clipart animations.
- Introduce an `AnimationBadge` widget to encapsulate badge rendering using `BadgePaint` and `AnimationBadgeProvider`.
- Improve badge loading, saving, and text/edit flows by centralizing helpers (e.g., `BadgeLoaderHelper`, `BadgeTextStorage`) and updating references across providers and screens.

Documentation:
- Tidy various in-code license text blocks and About screen content for better formatting.

Tests:
- Update unit and integration tests to match the new module layout, imports, and service locator names.