### PR TITLE
fix: restrict unsupported emoji input in badge creator

### DIFF
--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -77,6 +77,9 @@ class _HomeScreenState extends State<HomeScreen>
   static const _speedKey = 'badge_speed';
   static const _transitionKey = 'badge_transition';
   static const _effectsKey = 'badge_effects';
+  static final RegExp _emojiRegex = RegExp(
+    r'(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\udc00-\udfff]|\ud83d[\udc00-\udfff]|\ud83e[\udc00-\udfff]|[\uFE00-\uFE0F])',
+  );
 
   Timer? _debounceTimer;
 
@@ -329,6 +332,27 @@ class _HomeScreenState extends State<HomeScreen>
                       borderRadius: BorderRadius.circular(10.r),
                       elevation: 4,
                       child: ExtendedTextField(
+                        inputFormatters: [
+                          TextInputFormatter.withFunction((oldValue, newValue) {
+                            if (_emojiRegex.hasMatch(newValue.text)) {
+                              final strippedText =
+                                  newValue.text.replaceAll(_emojiRegex, ' ');
+                              ToastUtils()
+                                  .showToast("System emojis are not supported");
+                              final newSelectionOffset = math.min(
+                                newValue.selection.baseOffset,
+                                strippedText.length,
+                              );
+                              return TextEditingValue(
+                                text: strippedText,
+                                selection: TextSelection.collapsed(
+                                  offset: math.max(0, newSelectionOffset),
+                                ),
+                              );
+                            }
+                            return newValue;
+                          }),
+                        ],
                         controller: inlineimagecontroller,
                         specialTextSpanBuilder: ImageBuilder(),
                         style: Provider.of<FontProvider>(context)


### PR DESCRIPTION
Fixes #1552 

## Changes 
- Added inputFormatter to check if user try to add an emoji and show a Toast Message to tell user that emojis are not supported

## Screenshots / Recordings  
[Screencast From 2026-08-07 12-09-15.webm](https://github.com/user-attachments/assets/75d6bf07-debe-41c3-8a4f-c5b7ac915f54)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Restrict unsupported emoji input in the badge creator text field and inform users via a toast notification.

New Features:
- Add validation on the badge creator text input to prevent system emoji characters from being entered.

Enhancements:
- Display a toast message when users attempt to input unsupported emojis in the badge creator.