### PR TITLE
fix: restrict unsupported emoji input in badge creator

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -249,5 +249,6 @@
   "couldNotGenerateQrImage": "Could not generate QR image.",
   "couldNotShareQrImage": "Could not share QR image.",
   "qrShareInstruction": "Scan this code from another device, or tap share to send the QR image.",
-  "turnBLEOn": "Please turn on Bluetooth in your settings"
+  "turnBLEOn": "Please turn on Bluetooth in your settings",
+  "notSupportedEmojis": "System emojis are not supported"
 }

--- a/lib/view/widgets/badge_text_input_field.dart
+++ b/lib/view/widgets/badge_text_input_field.dart
@@ -7,9 +7,11 @@ import 'package:extended_text_field/extended_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:get_it/get_it.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
+import '../../others/localization_service.dart';
 import '../../others/toast_utils.dart';
 
 class BadgeTextInputField extends StatelessWidget {
@@ -59,6 +61,8 @@ class BadgeTextInputField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = GetIt.instance.get<LocalizationService>().l10n;
+
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 15.w, vertical: 8.h),
       child: Material(
@@ -70,7 +74,7 @@ class BadgeTextInputField extends StatelessWidget {
             TextInputFormatter.withFunction((oldValue, newValue) {
               if (_emojiRegex.hasMatch(newValue.text)) {
                 final strippedText = newValue.text.replaceAll(_emojiRegex, ' ');
-                ToastUtils().showToast("System emojis are not supported");
+                ToastUtils().showToast(l10n.notSupportedEmojis);
                 final newSelectionOffset = math.min(
                   newValue.selection.baseOffset,
                   strippedText.length,

--- a/lib/view/widgets/badge_text_input_field.dart
+++ b/lib/view/widgets/badge_text_input_field.dart
@@ -5,9 +5,12 @@ import 'package:badgemagic/providers/font_provider.dart';
 import 'package:badgemagic/view/widgets/special_text_field.dart';
 import 'package:extended_text_field/extended_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+
+import '../../others/toast_utils.dart';
 
 class BadgeTextInputField extends StatelessWidget {
   final TextEditingController controller;
@@ -50,6 +53,10 @@ class BadgeTextInputField extends StatelessWidget {
     }
   }
 
+  static final RegExp _emojiRegex = RegExp(
+    r'(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\udc00-\udfff]|\ud83d[\udc00-\udfff]|\ud83e[\udc00-\udfff]|[\uFE00-\uFE0F])',
+  );
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -59,6 +66,26 @@ class BadgeTextInputField extends StatelessWidget {
         borderRadius: BorderRadius.circular(10.r),
         elevation: 4,
         child: ExtendedTextField(
+          inputFormatters: [
+            TextInputFormatter.withFunction((oldValue, newValue) {
+              if (_emojiRegex.hasMatch(newValue.text)) {
+                final strippedText = newValue.text.replaceAll(_emojiRegex, ' ');
+                ToastUtils().showToast("System emojis are not supported");
+                final newSelectionOffset = math.min(
+                  newValue.selection.baseOffset,
+                  strippedText.length,
+                );
+
+                return TextEditingValue(
+                  text: strippedText,
+                  selection: TextSelection.collapsed(
+                    offset: math.max(0, newSelectionOffset),
+                  ),
+                );
+              }
+              return newValue;
+            }),
+          ],
           controller: controller,
           specialTextSpanBuilder: ImageBuilder(),
           style: Provider.of<FontProvider>(context).selectedFont != null


### PR DESCRIPTION
Fixes #1552 

## Changes 
Now the app block the user if it try to insert some personal emoji. In this case show a toast message that tell to user "emoji are not supported" and does not add the emoji in the textfield. If user paste a text with some emojis inside the app paste only the text and replace emoji with some whitespace

## Screenshots / Recordings  

https://github.com/user-attachments/assets/a9edf9a9-a66c-4adc-be5e-afe1f9c6cc6d


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Bug Fixes:
- Prevent unsupported emoji characters from being entered into badge text fields and replace pasted emojis with spaces while notifying users.

## Summary by Sourcery

Bug Fixes:
- Block unsupported emoji characters in badge text fields, notify users when they are removed, and replace pasted emojis with spaces.