### PR TITLE
fix: restore underline tab bar on home screen

### DIFF
--- a/lib/others/file_helper.dart
+++ b/lib/others/file_helper.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:badgemagic/models/data.dart';
-import 'package:badgemagic/others/badge_text_storage.dart';
+import 'package:badgemagic/storage/badge_text_storage.dart';
 import 'package:badgemagic/others/byte_array_utils.dart';
 import 'package:badgemagic/others/image_utils.dart';
 import 'package:badgemagic/others/toast_utils.dart';

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -311,7 +311,6 @@ class _HomeScreenState extends State<HomeScreen>
                   );
                   final tabBar = BadgeControlTabBar(
                     controller: _tabController,
-                    isNarrow: isPhone,
                   );
                   final dialTabView = BadgeControlTabView(
                     controller: _tabController,
@@ -327,24 +326,6 @@ class _HomeScreenState extends State<HomeScreen>
                         _showBleTransferDialog(context, inlineImageProvider),
                   );
 
-                  Widget cardWrap(Widget child) => Container(
-                        margin: EdgeInsets.fromLTRB(12.w, 8.h, 12.w, 12.h),
-                        clipBehavior: Clip.antiAlias,
-                        decoration: BoxDecoration(
-                          color: colorSurface,
-                          borderRadius: BorderRadius.circular(20.r),
-                          border: Border.all(color: const Color(0xFFEDEDED)),
-                          boxShadow: const [
-                            BoxShadow(
-                              color: Color.fromRGBO(0, 0, 0, 0.05),
-                              blurRadius: 14,
-                              offset: Offset(0, 4),
-                            ),
-                          ],
-                        ),
-                        child: child,
-                      );
-
                   final buttonBar = Padding(
                     padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 12.h),
                     child: actionButtons,
@@ -356,16 +337,8 @@ class _HomeScreenState extends State<HomeScreen>
                         badgePreview,
                         textField,
                         clipartPicker,
-                        Expanded(
-                          child: cardWrap(
-                            Column(
-                              children: [
-                                tabBar,
-                                Expanded(child: dialTabView),
-                              ],
-                            ),
-                          ),
-                        ),
+                        tabBar,
+                        Expanded(child: dialTabView),
                         buttonBar,
                       ],
                     );
@@ -384,18 +357,11 @@ class _HomeScreenState extends State<HomeScreen>
                               badgePreview,
                               textField,
                               clipartPicker,
-                              cardWrap(
-                                Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    tabBar,
-                                    SizedBox(
-                                      height: (ScreenUtil().screenHeight * 0.33)
-                                          .clamp(240.0, 380.0),
-                                      child: dialTabView,
-                                    ),
-                                  ],
-                                ),
+                              tabBar,
+                              SizedBox(
+                                height: (ScreenUtil().screenHeight * 0.33)
+                                    .clamp(240.0, 380.0),
+                                child: dialTabView,
                               ),
                             ],
                           ),

--- a/lib/view/widgets/badge_control_tab_bar.dart
+++ b/lib/view/widgets/badge_control_tab_bar.dart
@@ -6,33 +6,20 @@ import 'package:get_it/get_it.dart';
 
 class BadgeControlTabBar extends StatelessWidget {
   final TabController controller;
-  final bool isNarrow;
 
   const BadgeControlTabBar({
     super.key,
     required this.controller,
-    required this.isNarrow,
   });
 
   @override
   Widget build(BuildContext context) {
     final l10n = GetIt.instance.get<LocalizationService>().l10n;
-    return Container(
-      margin: EdgeInsets.fromLTRB(8.w, 8.h, 8.w, 4.h),
-      padding: EdgeInsets.all(4.w),
-      decoration: BoxDecoration(
-        color: colorSurfaceSubtle,
-        borderRadius: BorderRadius.circular(30.r),
-      ),
+    return Padding(
+      padding: EdgeInsets.only(top: 8.h),
       child: TabBar(
         isScrollable: false,
         indicatorSize: TabBarIndicatorSize.tab,
-        dividerColor: colorTransparent,
-        indicator: BoxDecoration(
-          color: colorPrimary,
-          borderRadius: BorderRadius.circular(30.r),
-        ),
-        splashBorderRadius: BorderRadius.circular(30.r),
         labelStyle: TextStyle(
           fontSize: 14.sp,
           fontWeight: FontWeight.w600,
@@ -42,15 +29,16 @@ class BadgeControlTabBar extends StatelessWidget {
           fontSize: 14.sp,
           fontWeight: FontWeight.w500,
         ),
-        labelColor: colorOnPrimary,
+        labelColor: colorOnSurface,
         unselectedLabelColor: mdGrey400,
+        indicatorColor: colorPrimary,
         controller: controller,
         splashFactory: InkRipple.splashFactory,
-        overlayColor: WidgetStateProperty.all(colorTransparent),
-        labelPadding: EdgeInsets.symmetric(
-          horizontal: 4.w,
-          vertical: isNarrow ? 1.h : 2.h,
+        overlayColor: WidgetStateProperty.resolveWith<Color?>(
+          (states) =>
+              states.contains(WidgetState.pressed) ? dividerColor : null,
         ),
+        labelPadding: EdgeInsets.symmetric(horizontal: 4.w),
         tabs: [
           Tab(
             key: const ValueKey('tab_speed'),


### PR DESCRIPTION
## Summary
- Reverts the home screen tab selector from the red pill/capsule style (introduced in #1821, re-applied in #1871) back to the older underline indicator.
- Removes the white card wrapper around the tab bar and tab content so the middle section is less visually dominant.

## Changes
- `BadgeControlTabBar`: underline `indicatorColor` with black selected labels instead of solid red pill background
- `HomeScreen`: drop `cardWrap` container; tabs and content sit directly in the layout again

## Test plan
- [x] `flutter analyze` on changed files (no new issues)
- [ ] Open home screen on Android — tabs show underline selection, not red pill
- [ ] Switch between Speed / Transition / Effects / Animation tabs — content updates correctly
- [ ] Save and Transfer buttons still visible at bottom on phone layout
- [ ] Desktop layout still usable (wide window)

## Summary by Sourcery

Restore the home screen’s simpler underline tab presentation and reduce visual emphasis around the tab content.

Bug Fixes:
- Restore the home screen tab selector to an underline-based style with black selected labels instead of the red capsule treatment.

Enhancements:
- Remove the home screen card wrapper so the tab bar and editor content integrate directly into the layout across phone and desktop views.
- Update the badge text storage import to its new storage package location.