### PR TITLE
feat: add mouse scroll support for speed dial on desktop

### DIFF
--- a/lib/view/widgets/speed_dial.dart
+++ b/lib/view/widgets/speed_dial.dart
@@ -213,7 +213,8 @@ class _RadialDialState extends State<RadialDial> {
               final delta = _scrollAccumulator > 0 ? -1 : 1;
               _scrollAccumulator = 0;
               final current = outerValueProvider.getOuterValue();
-              final newValue = (current + delta).clamp(1, maxValue.toInt()).toInt();
+              final newValue =
+                  (current + delta).clamp(1, maxValue.toInt()).toInt();
               if (newValue != current) {
                 setState(() {
                   outerValueProvider.setDialValue(newValue);

--- a/lib/view/widgets/speed_dial.dart
+++ b/lib/view/widgets/speed_dial.dart
@@ -213,7 +213,7 @@ class _RadialDialState extends State<RadialDial> {
               final delta = _scrollAccumulator > 0 ? -1 : 1;
               _scrollAccumulator = 0;
               final current = outerValueProvider.getOuterValue();
-              final newValue = (current + delta).clamp(1, maxValue.toInt());
+              final newValue = (current + delta).clamp(1, maxValue.toInt()).toInt();
               if (newValue != current) {
                 setState(() {
                   outerValueProvider.setDialValue(newValue);


### PR DESCRIPTION
Fixes #1922 

## Changes 
On desktop, you can now scroll the mouse wheel over the speed dial to change the speed. Previously, only click-and-drag worked.
## Screenshots / Recordings  

https://github.com/user-attachments/assets/05ac2b3c-b5f1-47bb-a498-51128123b7f8


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `constants.dart` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **Code analyzation**: My code passes analyzations run in _flutter analyze_ and tests run in _flutter test_.

## Summary by Sourcery

Support changing the desktop speed dial value with mouse-wheel scrolling.

New Features:
- Enable desktop mouse-wheel scrolling to adjust the speed dial value.

Bug Fixes:
- Ensure the calculated speed dial value is an integer before applying it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-wheel and trackpad scrolling support to adjust the speed dial value.
  * Each scroll step changes the value by one within the supported range of 1–8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->